### PR TITLE
feat: add PHPStan for static analysis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ stop:
 	docker compose stop
 lint:
 	docker compose run --rm fuelphp backend/vendor/bin/phpcs --standard=backend/phpcs.xml backend
+phpstan:
+	docker compose run --rm fuelphp backend/vendor/bin/phpstan analyse -c backend/phpstan.neon
 test-unit:
 	docker compose run --rm fuelphp backend/vendor/bin/phpunit backend/tests
 dns-mapping:

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -22,8 +22,10 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^9.6",
+    "phpstan/phpstan": "^1.10",
     "slevomat/coding-standard": "^8.17",
-    "phpcompatibility/php-compatibility": "^9.3"
+    "phpcompatibility/php-compatibility": "^9.3",
+    "phpstan/phpstan-phpunit": "^1.3"
   },
   "config": {
     "allow-plugins": {

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5d5e57ba87b85199102641471bf1e5a7",
+    "content-hash": "0ffc5f3fa2f6d832b4961ada2522ba05",
     "packages": [
         {
             "name": "psr/container",
@@ -566,6 +566,111 @@
                 "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
             },
             "time": "2026-01-25T14:56:51+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.12.33",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/37982d6fc7cbb746dda7773530cda557cdf119e1",
+                "reference": "37982d6fc7cbb746dda7773530cda557cdf119e1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-28T20:30:03+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-phpunit",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-phpunit.git",
+                "reference": "72a6721c9b64b3e4c9db55abbc38f790b318267e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/72a6721c9b64b3e4c9db55abbc38f790b318267e",
+                "reference": "72a6721c9b64b3e4c9db55abbc38f790b318267e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.12"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<7.0"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^4.13.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-strict-rules": "^1.5.1",
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon",
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPUnit extensions and rules for PHPStan",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
+                "source": "https://github.com/phpstan/phpstan-phpunit/tree/1.4.2"
+            },
+            "time": "2024-12-17T17:20:49+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/backend/phpstan.neon
+++ b/backend/phpstan.neon
@@ -1,0 +1,39 @@
+includes:
+    - vendor/phpstan/phpstan-phpunit/extension.neon
+
+parameters:
+    level: 5
+    paths:
+        - src
+        - tests
+    ignoreErrors:
+        # External SDKs not in backend's composer dependencies
+        # These classes are available through FuelPHP's vendor at runtime
+        -
+            identifier: class.notFound
+            paths:
+                - src/SharedKernel/Infrastructure/EventSystem/SqsAsync*
+                - src/SharedKernel/Infrastructure/Logger/MonologLogger.php
+                - src/SharedKernel/Infrastructure/Storage/S3*
+        -
+            message: '#Psr\\Http\\Message\\StreamInterface#'
+        -
+            message: '#GuzzleHttp\\#'
+        -
+            message: '#\(bool\|int\|Redis\)#'
+        # PHPUnit mock methods on typed properties
+        # PHPStan-phpunit only recognises mocks from $this->createMock() inline,
+        # not when stored to a typed property first
+        -
+            message: '#Call to an undefined method .+::(method|expects|willReturn)\(\)#'
+            paths:
+                - tests
+        -
+            message: '#expects .+, PHPUnit\\Framework\\MockObject\\MockObject given#'
+            paths:
+                - tests
+        -
+            message: '#expects class-string<.+>, string given#'
+            paths:
+                - tests
+    reportUnmatchedIgnoredErrors: false


### PR DESCRIPTION
adds phpstan + phpstan-phpunit as dev deps, `backend/phpstan.neon` config, and `make phpstan` target.

## Test plan
- [x] `make phpstan` runs without config errors