### PR TITLE
feat: CQRS rate-limiting with per-user-type throttling

### DIFF
--- a/backend/docs/SharedKernel/Security.md
+++ b/backend/docs/SharedKernel/Security.md
@@ -2214,6 +2214,8 @@ private function generateMockToken(string $userId, string $email): string
 
 **Purpose**: Represents an authenticated user with core identity information and flexible profile metadata.
 
+**Note**: `AuthenticatedUser` now includes a `$type` field (added for throttle system integration). The `type` field uses `UserType` constants (`admin`, `partner`, `customer`) to identify the user category. This is used by the CQRS throttle decorator to resolve per-user-type rate limits. `SecurityContextInterface` has also been implemented at `Domain/Security/SecurityContextInterface.php`.
+
 **Class Definition**:
 ```php
 class AuthenticatedUser
@@ -2222,6 +2224,7 @@ class AuthenticatedUser
         private string $id,
         private string $email,
         private array $roles,
+        private string $type = UserType::CUSTOMER,
         private array $profileMetadata = []
     ) {}
     
@@ -2229,6 +2232,7 @@ class AuthenticatedUser
     public function getId(): string { return $this->id; }
     public function getEmail(): string { return $this->email; }
     public function getRoles(): array { return $this->roles; }
+    public function getType(): string { return $this->type; }
     
     // Profile metadata methods
     public function getProfileMetadata(): array { return $this->profileMetadata; }

--- a/backend/docs/adr/006-cqrs-message-bus.md
+++ b/backend/docs/adr/006-cqrs-message-bus.md
@@ -165,5 +165,5 @@ A missing handler is a programmer error (misconfigured registry), not a runtime 
 ### Open Items
 - Transaction decorator for command bus — wraps handler execution in a database transaction
 - Cache decorator for query bus — caches responses by query identity
-- Throttle decorator — rate limits bus dispatches
+- ~~Throttle decorator — rate limits bus dispatches~~ → ADR-007
 - Integration with event system (ADR-005) — command handler decorator to collect domain events from aggregates and store in outbox atomically

--- a/backend/docs/adr/007-rate-limiting-architecture.md
+++ b/backend/docs/adr/007-rate-limiting-architecture.md
@@ -1,0 +1,208 @@
+# ADR-007: Rate Limiting Architecture
+
+**Status:** Accepted
+**Date:** 2026-04-18
+
+## Context
+
+The system needs rate limiting at two levels: HTTP-level flood protection for anonymous traffic, and CQRS-level throttling for authenticated users and specific public endpoints. The CQRS throttle must support different limits per user type (admin, partner, customer, system worker), per-command/query overrides, progressive penalties for repeat offenders, and fail-open behavior when the storage backend is unavailable. The implementation must be framework-agnostic (PHP 7.4 compatible in `backend/src/`) for the CQRS layer, integrate with the existing CQRS decorator chain (ADR-006), and support the ongoing FuelPHP-to-Laravel migration.
+
+Key requirements:
+- HTTP layer: broad IP-based throttle for anonymous users, framework-specific
+- CQRS layer: rate limit authenticated users by user type + ID, with per-command overrides for both authenticated and anonymous
+- Different default limits per user type — admins and system workers exempt
+- Progressive penalties that escalate block duration on repeated violations
+- Fail-open on storage driver failure — never block legitimate traffic due to infrastructure issues
+- No coupling between commands/queries and throttle configuration
+- Driver-agnostic design — Redis is the initial driver, but the throttle layer must not leak Redis-specific concerns
+
+## Decision
+
+### Two-Tier Rate Limiting: Global Defaults + Per-Command Overrides
+
+The throttle system operates at two layers:
+
+**HTTP layer** (framework-specific) — Broad IP-based throttle for anonymous users. Catches floods, scrapers, and malformed requests before they reach the CQRS bus. Authenticated users skip this layer.
+
+**CQRS layer** (framework-agnostic) — Two complementary tiers:
+
+1. **Global defaults per user type** — A shared counter across all commands that caps total throughput per authenticated user. A customer making 50 requests across any combination of commands shares one counter with one limit (e.g., 30 warning / 50 block per minute). This prevents aggregate abuse without requiring per-command configuration.
+
+2. **Per-command overrides for sensitive endpoints** — Commands that are expensive, disruptive, or abuse-prone (e.g., contact forms, bulk imports, payment endpoints) get their own counter with tighter limits. These apply to both authenticated and anonymous users. For anonymous users, only per-command overrides apply at the CQRS level — broad anonymous protection is the HTTP layer's responsibility.
+
+The majority of commands use global defaults with zero configuration. Per-command overrides are added only when a specific command proves it needs protection. This follows the standard API rate-limiting pattern used by Stripe, GitHub, and AWS API Gateway: a global budget with per-endpoint overrides, with independent counters per tier.
+
+### Config-Driven, Not Interface-Driven
+
+Throttle configuration is centralized in a config class (`ThrottleConfigDefaults`) rather than declared on individual commands/queries via a marker interface. A `ThrottleAwareInterface` was the initial implementation but was replaced because:
+- It scattered throttle policy across the codebase — each command declared its own limits
+- Commands carried identity resolution logic that belongs in infrastructure
+- Warning/block callbacks coupled commands to throttle mechanics — the decorator already handles events and exceptions
+- Adding or changing throttle rules required modifying command classes, not a single config
+- The project already uses centralized config for security permissions (Security.md) — throttle should follow the same pattern
+
+The centralized approach uses a `ThrottleConfigResolverInterface` with a single `resolve()` method. The resolver holds the full config array and resolves the appropriate `ThrottleConfig` at runtime based on the command class and user type.
+
+### Layered Config Resolution
+
+The resolver follows a 6-step fallback chain:
+
+1. **Excluded?** — Command is in the exclusion list → skip throttle
+2. **Exact user type match** — Per-command config has a key matching the user type (e.g., `'partner'`) → use it
+3. **Authenticated catch-all** — Per-command config has an `'authenticated'` key and user is authenticated → use it
+4. **Flat config** — Per-command config has `warning_limit` at top level (no user type split) → use it for all users
+5. **User type default** — Global defaults for this user type → use it (`null` means exempt)
+6. **No match** → skip throttle
+
+The `'authenticated'` catch-all (step 3) exists because per-command configs often need only two tiers: authenticated vs anonymous. Without it, every per-command split config would need to repeat entries for `'partner'`, `'customer'`, etc. Exact user type keys (step 2) take priority over the catch-all, allowing specific overrides when needed.
+
+### Identity Resolution via SecurityContext and RequestContext
+
+The throttle decorator resolves the caller's identity automatically:
+- **Authenticated users** — identified by `$userType . ':' . $user->getId()` (e.g., `customer:42`, `partner:7`), resolved via `SecurityContextInterface`
+- **Anonymous users** — identified by `'ip:' . $clientIp`, resolved via `RequestContextInterface`
+
+Identity resolution was initially on the command, but this was moved to the decorator because:
+- The command shouldn't know about the HTTP request or session context
+- `SecurityContextInterface` is populated by the framework before the CQRS chain runs — the decorator can read it directly
+- `RequestContextInterface` provides the IP address — a framework-level concern that doesn't belong on a domain command
+
+`SecurityContextInterface` and `RequestContextInterface` are interface-only in the domain/application layer. Concrete implementations live in the framework directories (FuelPHP reads from `Input::ip()`, Laravel from `$request->ip()`).
+
+### User Types, Not Roles
+
+Throttle limits are keyed by user type (`UserType::ADMIN`, `PARTNER`, `CUSTOMER`, `SYSTEM`, `ANONYMOUS`), not by role. User type represents which authentication provider/table the user comes from — it's a fixed identity characteristic, not a permission grant. One user has exactly one type. `AuthenticatedUser` was extended with a `$type` field (defaulting to `UserType::CUSTOMER` for backward compatibility) to carry this information through the security context.
+
+Roles were considered but rejected because:
+- A user with multiple roles (`['user', 'manager']`) would need conflict resolution — which role's limits apply?
+- Roles are about authorization (what you can do), not identity (who you are)
+- The admin panel, partner portal, and customer portal are separate authentication contexts with separate tables — user type naturally maps to this
+
+`UserType::SYSTEM` was added for background workers and batch operations. Workers set a system-level `AuthenticatedUser` in `SecurityContextInterface` at bootstrap. The config exempts `SYSTEM` with `null` defaults, so workers are never throttled. This avoids maintaining exclusion lists of worker commands and works with the shared DI container (no separate config for workers).
+
+`UserType::ANONYMOUS` is a config-only concept — it represents the absence of an authenticated user. It's included in `UserType` constants so the config key space is consistent and validatable.
+
+### Decorator Chain Order
+
+The decorator chain order (outermost → innermost) is:
+
+```
+ThrottleDecorator → LoggerDecorator → TransactionDecorator → Handler
+```
+
+(SecurityDecorator will be inserted between Throttle and Logger when the security module is implemented.)
+
+- **Throttle outermost** — reject abusers before any work. `SecurityContextInterface` is populated by the framework middleware before the CQRS chain, not by the security decorator, so the throttle decorator has access to user identity.
+- **Logger outside transaction** — captures the full execution time including transaction commit/rollback. If the logger were inside the transaction, slow commits would be invisible in logs.
+- **Transaction innermost** — wraps only the handler's DB work and domain event collection.
+
+### Anonymous Protection Split: HTTP + CQRS
+
+The HTTP layer (described in the two-tier section above) checks authentication status before throttling: if `Auth::check()` is true, the request passes through without IP-based throttle. This prevents blocking legitimate authenticated users behind shared IPs (corporate NAT, VPN). Implemented as a framework-specific controller base class (FuelPHP: abstract controller with `before()` override, Laravel: middleware).
+
+At the CQRS level, there is no anonymous global default — broad anonymous protection is the HTTP layer's responsibility. Per-command anonymous overrides can still be configured for specific public endpoints (e.g., contact forms: 5/hour, registration: 10/hour).
+
+A single-layer approach (all anonymous throttling at CQRS) was the initial design but was replaced because:
+- Malformed requests, invalid routes, and controller-level validation failures never reach the CQRS bus — they bypass the throttle entirely
+- Tight IP limits at the CQRS level would block authenticated users behind shared IPs
+- The HTTP layer is the natural place for IP-based flood protection — it sees all requests regardless of routing outcome
+
+### Fail-Open with Exception Layering
+
+When the storage driver is unavailable, the throttle allows the request through rather than blocking it. This is a deliberate trade-off — temporary loss of rate limiting is preferable to a total service outage.
+
+The fail-open implementation uses two layers of exception handling:
+
+1. **`ThrottleDriverException`** — A driver-agnostic exception thrown by `RedisThrottler` when Redis is unavailable. The decorator catches this and logs a warning.
+2. **`ThrottleException`** — Created before event firing and thrown after the try-catch block. This ensures a throttle block decision is never swallowed by a driver failure in the event-firing path.
+
+The initial implementation caught `RedisConnectionException` directly in the decorator trait, coupling the CQRS layer to Redis. This was replaced with `ThrottleDriverException` so the decorator only knows about throttle abstractions. Each driver implementation wraps its connection-specific exceptions into `ThrottleDriverException`.
+
+### Progressive Penalties via Violation Counter
+
+When a user exceeds the block limit, the block duration escalates based on their violation count:
+- 1st violation: 5 minutes
+- 2nd violation: 1 hour
+- 3rd+ violation: 3 hours (caps at the last penalty tier)
+
+The violation counter has its own TTL (recovery period). If the user stops offending for the recovery period, the violation counter resets and the next offense starts at the first penalty tier.
+
+The Redis implementation uses `INCR` + `EXPIRE` (set TTL on first increment) rather than `SETNX` + `INCR`. The `SETNX`/`INCR` pattern has a theoretical race condition: if the key expires between `SETNX` failing and `INCR` executing, `INCR` creates a new key without a TTL, leaving it in Redis forever. The `INCR` + `EXPIRE` pattern avoids this.
+
+### Shared Default Counter vs Per-Command Counters
+
+To implement the two-tier model, default commands share a single `__default__` counter per user, while per-command overrides get their own counter scoped by command short name. This prevents key explosion in Redis (thousands of per-command keys per user) and ensures the global default actually caps total throughput rather than per-command throughput.
+
+The `ThrottleConfigResolver` returns a `ThrottleResolveResult` value object that carries both the `ThrottleConfig` and the scope name (`__default__` for defaults, command short name for overrides). The trait passes the scope to the throttle factory, which uses it as the Redis key namespace.
+
+### Redis Key Structure
+
+All throttle state is stored in Redis with the key pattern:
+
+```
+throttle:{scope}:{identifier}:window:{windowId}   — request counter per time window
+throttle:{scope}:{identifier}:violations           — progressive penalty counter
+throttle:{scope}:{identifier}:blocked              — block timestamp
+```
+
+Where `{scope}` is `__default__` for commands using default limits, or the command short name for per-command overrides.
+
+Examples:
+```
+throttle:__default__:customer:42:window:28456789         — shared counter for all default commands
+throttle:CreateOrderCommand:customer:42:window:28456789  — per-command override (authenticated)
+throttle:ContactFormCommand:ip:192.168.1.50:window:...   — per-command override (anonymous)
+```
+
+The user type prefix in the identifier (`customer:42` vs `partner:42`) ensures users from different tables with overlapping IDs have separate counters. The scope uses the short class name (e.g., `CreateOrderCommand`) rather than the FQCN to keep Redis keys readable. If two bounded contexts have commands with the same short name, they share a counter — this is accepted as rare and arguably correct (same user, same action concept). All Redis operations go to the master node (write client) for strong consistency — reading counters from a replica could undercount due to replication lag.
+
+### Security: Generic Exception Messages
+
+`ThrottleException` uses a generic client-facing message: `"Too many requests. Please try again later."` The blocked identifier (e.g., `customer:42` or `ip:192.168.1.50`) is available only via `getIdentifier()` for server-side logging, and `getRetryAfter()` provides the seconds until the block expires for `Retry-After` headers.
+
+## Components
+
+| Component | Layer | Purpose |
+|---|---|---|
+| `ThrottleInterface` | Domain | Contract: `attempt()` and `clear()` |
+| `ThrottleConfig` | Domain | Value object: limits, window, penalties, recovery period |
+| `ThrottleResult` | Domain | Value object: allowed/warning/blocked with retry-after |
+| `ThrottleResolveResult` | Domain | Value object: resolved config + scope (`__default__` or command name) |
+| `ThrottleFactoryInterface` | Domain | Factory contract: `create(ThrottleConfig, string): ThrottleInterface` |
+| `ThrottleException` | Domain | Rate limit exceeded — generic message, identifier for logging |
+| `ThrottleDriverException` | Domain | Driver-agnostic connection failure |
+| `ThrottleConfigException` | Domain | Invalid configuration values |
+| `CqrsThrottleWarningEvent` | Domain | Async event: warning threshold crossed |
+| `CqrsThrottleBlockedEvent` | Domain | Async event: request blocked |
+| `UserType` | Domain | Constants: ADMIN, PARTNER, CUSTOMER, SYSTEM, ANONYMOUS |
+| `SecurityContextInterface` | Domain | Request-scoped user identity |
+| `ThrottleConfigResolverInterface` | Application | Contract: resolve config by command class and user type |
+| `RequestContextInterface` | Application | Client IP address |
+| `RedisThrottler` | Infrastructure | Redis sliding-window implementation |
+| `RedisThrottlerFactory` | Infrastructure | Creates `RedisThrottler` instances |
+| `ThrottleConfigResolver` | Infrastructure | 6-step config resolution with fallback chain |
+| `ThrottleConfigDefaults` | Infrastructure | Default throttle limits per user type |
+| `ThrottleLogicTrait` | Infrastructure | Shared decorator logic: identity resolution, throttle check, event firing |
+| `CommandThrottleDecorator` | Infrastructure | `CommandBusInterface` decorator |
+| `QueryThrottleDecorator` | Infrastructure | `QueryBusInterface` decorator |
+
+## Consequences
+
+### Positive
+- Two-layer approach catches abuse at the right level — HTTP for raw floods, CQRS for application-level abuse
+- Authenticated users skip IP-based throttle — no false blocks behind shared IPs
+- Centralized config keeps CQRS throttle policy in one reviewable place — no per-command interface pollution
+- Layered resolution provides granularity (per-command, per-user-type) with sensible defaults
+- User type-based exemption handles admin panels and background workers without exclusion lists
+- Driver-agnostic exceptions allow swapping Redis for another storage backend without changing the decorator
+- Fail-open with proper exception layering ensures blocks are enforced even when event firing fails
+- Generic exception messages prevent information leakage
+- Progressive penalties discourage repeat offenders while allowing recovery
+
+### Trade-offs
+- Anonymous protection is split across two layers — requires coordinating HTTP and CQRS throttle configs
+- Config resolution has multiple fallback steps — debugging "which config was applied?" requires understanding the chain
+- `UserType::ANONYMOUS` is not a real user type but is included in constants for config key consistency
+- New commands get throttled by defaults automatically — no opt-in required, which could surprise developers adding internal commands (mitigation: use `excluded` list or `SYSTEM` user type for workers)
+- `ThrottleConfigDefaults` is a static config class, not a file-based config — changing defaults requires a code deploy, not a config file change
+- HTTP layer throttle is framework-specific — each framework (FuelPHP, Laravel) needs its own implementation

--- a/backend/src/SharedKernel/Application/Http/RequestContextInterface.php
+++ b/backend/src/SharedKernel/Application/Http/RequestContextInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Application\Http;
+
+interface RequestContextInterface
+{
+    public function getClientIp(): string;
+}

--- a/backend/src/SharedKernel/Application/Throttle/ThrottleConfigResolverInterface.php
+++ b/backend/src/SharedKernel/Application/Throttle/ThrottleConfigResolverInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Application\Throttle;
+
+use SharedKernel\Domain\Throttle\ThrottleResolveResult;
+
+interface ThrottleConfigResolverInterface
+{
+    /**
+     * Resolve the throttle configuration for a given CQRS message and user type.
+     *
+     * Returns null if throttle should be skipped (excluded message, exempt user type, or no config).
+     * Returns ThrottleResolveResult with scope indicating per-command or default resolution.
+     *
+     * @param string $messageClass FQCN of the command or query
+     * @param string $messageType 'command' or 'query'
+     * @param string|null $userType UserType constant, or null for anonymous users
+     * @return ThrottleResolveResult|null
+     */
+    public function resolve(string $messageClass, string $messageType, ?string $userType): ?ThrottleResolveResult;
+}

--- a/backend/src/SharedKernel/Domain/Redis/RedisClientInterface.php
+++ b/backend/src/SharedKernel/Domain/Redis/RedisClientInterface.php
@@ -93,6 +93,15 @@ interface RedisClientInterface
     public function setnx(string $key, string $value, int $ttl = 0): bool;
 
     /**
+     * Set a timeout on key
+     * @param string $key The key to set expiry on
+     * @param int $ttl Time to live in seconds
+     * @return bool True if timeout was set, false if key does not exist
+     * @throws RedisConnectionException
+     */
+    public function expire(string $key, int $ttl): bool;
+
+    /**
      * Get value by key from master (write) node only
      * Use this for operations requiring strong consistency
      * @throws RedisConnectionException

--- a/backend/src/SharedKernel/Domain/Security/AuthenticatedUser.php
+++ b/backend/src/SharedKernel/Domain/Security/AuthenticatedUser.php
@@ -13,11 +13,17 @@ final class AuthenticatedUser
     /** @var array<string> */
     private array $roles;
 
-    public function __construct(string $id, string $email, array $roles = [])
+    private string $type;
+
+    /**
+     * @param array<string> $roles
+     */
+    public function __construct(string $id, string $email, array $roles = [], string $type = UserType::CUSTOMER)
     {
         $this->id = $id;
         $this->email = $email;
         $this->roles = $roles;
+        $this->type = $type;
     }
 
     public function getId(): string
@@ -33,5 +39,10 @@ final class AuthenticatedUser
     public function getRoles(): array
     {
         return $this->roles;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
     }
 }

--- a/backend/src/SharedKernel/Domain/Security/SecurityContextInterface.php
+++ b/backend/src/SharedKernel/Domain/Security/SecurityContextInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Domain\Security;
+
+interface SecurityContextInterface
+{
+    public function getCurrentUser(): ?AuthenticatedUser;
+
+    public function setCurrentUser(AuthenticatedUser $user): void;
+
+    public function hasAuthenticatedUser(): bool;
+
+    public function clearUser(): void;
+}

--- a/backend/src/SharedKernel/Domain/Security/UserType.php
+++ b/backend/src/SharedKernel/Domain/Security/UserType.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Domain\Security;
+
+final class UserType
+{
+    public const ADMIN = 'admin';
+    public const PARTNER = 'partner';
+    public const CUSTOMER = 'customer';
+    public const SYSTEM = 'system';
+    public const ANONYMOUS = 'anonymous';
+
+    /** @var array<string> */
+    private static array $validTypes = [
+        self::ADMIN,
+        self::PARTNER,
+        self::CUSTOMER,
+        self::SYSTEM,
+        self::ANONYMOUS,
+    ];
+
+    private function __construct()
+    {
+    }
+
+    public static function isValid(string $type): bool
+    {
+        return in_array($type, self::$validTypes, true);
+    }
+
+    /**
+     * @return array<string>
+     */
+    public static function getAll(): array
+    {
+        return self::$validTypes;
+    }
+}

--- a/backend/src/SharedKernel/Domain/Throttle/Events/CqrsThrottleBlockedEvent.php
+++ b/backend/src/SharedKernel/Domain/Throttle/Events/CqrsThrottleBlockedEvent.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Domain\Throttle\Events;
+
+use DateTimeImmutable;
+use Exception;
+use SharedKernel\Domain\EventSystem\AbstractEvent;
+use SharedKernel\Domain\EventSystem\AsyncEventInterface;
+
+final class CqrsThrottleBlockedEvent extends AbstractEvent implements AsyncEventInterface
+{
+    private string $messageType;
+    private string $messageClass;
+    private string $identifier;
+    private int $retryAfter;
+    private string $clientIp;
+    private ?string $userType;
+
+    private function __construct(
+        string $messageType,
+        string $messageClass,
+        string $identifier,
+        int $retryAfter,
+        string $clientIp,
+        ?string $userType,
+        ?string $id = null,
+        ?int $version = null,
+        ?DateTimeImmutable $occurredAt = null
+    ) {
+        parent::__construct($id, $version, $occurredAt);
+        $this->messageType = $messageType;
+        $this->messageClass = $messageClass;
+        $this->identifier = $identifier;
+        $this->retryAfter = $retryAfter;
+        $this->clientIp = $clientIp;
+        $this->userType = $userType;
+    }
+
+    public static function create(
+        string $messageType,
+        string $messageClass,
+        string $identifier,
+        int $retryAfter,
+        string $clientIp,
+        ?string $userType
+    ): self {
+        return new self($messageType, $messageClass, $identifier, $retryAfter, $clientIp, $userType);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public static function fromPayload(array $payload): self
+    {
+        return new self(
+            $payload['message_type'],
+            $payload['message_class'],
+            $payload['identifier'],
+            $payload['retry_after'],
+            $payload['client_ip'] ?? '',
+            $payload['user_type'] ?? null,
+            $payload['id'] ?? null,
+            $payload['version'] ?? null,
+            isset($payload['occurred_at']) ? new DateTimeImmutable($payload['occurred_at']) : null
+        );
+    }
+
+    public function getMessageType(): string
+    {
+        return $this->messageType;
+    }
+
+    public function getMessageClass(): string
+    {
+        return $this->messageClass;
+    }
+
+    public function getIdentifier(): string
+    {
+        return $this->identifier;
+    }
+
+    public function getRetryAfter(): int
+    {
+        return $this->retryAfter;
+    }
+
+    public function getClientIp(): string
+    {
+        return $this->clientIp;
+    }
+
+    public function getUserType(): ?string
+    {
+        return $this->userType;
+    }
+
+    public function serialize(): array
+    {
+        return [
+            'message_type' => $this->messageType,
+            'message_class' => $this->messageClass,
+            'identifier' => $this->identifier,
+            'retry_after' => $this->retryAfter,
+            'client_ip' => $this->clientIp,
+            'user_type' => $this->userType,
+        ];
+    }
+}

--- a/backend/src/SharedKernel/Domain/Throttle/Events/CqrsThrottleWarningEvent.php
+++ b/backend/src/SharedKernel/Domain/Throttle/Events/CqrsThrottleWarningEvent.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Domain\Throttle\Events;
+
+use DateTimeImmutable;
+use Exception;
+use SharedKernel\Domain\EventSystem\AbstractEvent;
+use SharedKernel\Domain\EventSystem\AsyncEventInterface;
+
+final class CqrsThrottleWarningEvent extends AbstractEvent implements AsyncEventInterface
+{
+    private string $messageType;
+    private string $messageClass;
+    private string $identifier;
+    private int $requestCount;
+    private string $clientIp;
+    private ?string $userType;
+
+    private function __construct(
+        string $messageType,
+        string $messageClass,
+        string $identifier,
+        int $requestCount,
+        string $clientIp,
+        ?string $userType,
+        ?string $id = null,
+        ?int $version = null,
+        ?DateTimeImmutable $occurredAt = null
+    ) {
+        parent::__construct($id, $version, $occurredAt);
+        $this->messageType = $messageType;
+        $this->messageClass = $messageClass;
+        $this->identifier = $identifier;
+        $this->requestCount = $requestCount;
+        $this->clientIp = $clientIp;
+        $this->userType = $userType;
+    }
+
+    public static function create(
+        string $messageType,
+        string $messageClass,
+        string $identifier,
+        int $requestCount,
+        string $clientIp,
+        ?string $userType
+    ): self {
+        return new self($messageType, $messageClass, $identifier, $requestCount, $clientIp, $userType);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public static function fromPayload(array $payload): self
+    {
+        return new self(
+            $payload['message_type'],
+            $payload['message_class'],
+            $payload['identifier'],
+            $payload['request_count'],
+            $payload['client_ip'] ?? '',
+            $payload['user_type'] ?? null,
+            $payload['id'] ?? null,
+            $payload['version'] ?? null,
+            isset($payload['occurred_at']) ? new DateTimeImmutable($payload['occurred_at']) : null
+        );
+    }
+
+    public function getMessageType(): string
+    {
+        return $this->messageType;
+    }
+
+    public function getMessageClass(): string
+    {
+        return $this->messageClass;
+    }
+
+    public function getIdentifier(): string
+    {
+        return $this->identifier;
+    }
+
+    public function getRequestCount(): int
+    {
+        return $this->requestCount;
+    }
+
+    public function getClientIp(): string
+    {
+        return $this->clientIp;
+    }
+
+    public function getUserType(): ?string
+    {
+        return $this->userType;
+    }
+
+    public function serialize(): array
+    {
+        return [
+            'message_type' => $this->messageType,
+            'message_class' => $this->messageClass,
+            'identifier' => $this->identifier,
+            'request_count' => $this->requestCount,
+            'client_ip' => $this->clientIp,
+            'user_type' => $this->userType,
+        ];
+    }
+}

--- a/backend/src/SharedKernel/Domain/Throttle/Exceptions/ThrottleConfigException.php
+++ b/backend/src/SharedKernel/Domain/Throttle/Exceptions/ThrottleConfigException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Domain\Throttle\Exceptions;
+
+use InvalidArgumentException;
+
+class ThrottleConfigException extends InvalidArgumentException
+{
+    public static function missingRequiredKeys(): self
+    {
+        return new self('Throttle configuration must include warning_limit, block_limit, and window');
+    }
+
+    public static function warningLimitTooHigh(): self
+    {
+        return new self('warning_limit must be less than block_limit');
+    }
+
+    public static function invalidValue(string $key, string $reason): self
+    {
+        return new self("Invalid throttle configuration value for '$key': $reason");
+    }
+}

--- a/backend/src/SharedKernel/Domain/Throttle/Exceptions/ThrottleDriverException.php
+++ b/backend/src/SharedKernel/Domain/Throttle/Exceptions/ThrottleDriverException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Domain\Throttle\Exceptions;
+
+use RuntimeException;
+use Throwable;
+
+class ThrottleDriverException extends RuntimeException
+{
+    public function __construct(string $message = '', ?Throwable $previous = null)
+    {
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/backend/src/SharedKernel/Domain/Throttle/Exceptions/ThrottleException.php
+++ b/backend/src/SharedKernel/Domain/Throttle/Exceptions/ThrottleException.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Domain\Throttle\Exceptions;
+
+use RuntimeException;
+
+class ThrottleException extends RuntimeException
+{
+    private int $retryAfter;
+    private string $identifier;
+
+    public function __construct(int $retryAfter, string $identifier = '')
+    {
+        $this->retryAfter = $retryAfter;
+        $this->identifier = $identifier;
+
+        parent::__construct('Too many requests. Please try again later.');
+    }
+
+    public static function blockedIdentifier(int $retryAfter, string $identifier): self
+    {
+        return new self($retryAfter, $identifier);
+    }
+
+    public function getRetryAfter(): int
+    {
+        return $this->retryAfter;
+    }
+
+    public function getIdentifier(): string
+    {
+        return $this->identifier;
+    }
+}

--- a/backend/src/SharedKernel/Domain/Throttle/ThrottleConfig.php
+++ b/backend/src/SharedKernel/Domain/Throttle/ThrottleConfig.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Domain\Throttle;
+
+use SharedKernel\Domain\Throttle\Exceptions\ThrottleConfigException;
+
+class ThrottleConfig
+{
+    private int $warningLimit;
+    private int $blockLimit;
+    private int $window;
+    /** @var array<int> */
+    private array $penalties;
+    private int $recoveryPeriod;
+
+    public function __construct(array $config)
+    {
+        $this->validateAndSetConfig($config);
+    }
+
+    public static function fromArray(array $config): self
+    {
+        return new self($config);
+    }
+
+    private function validateAndSetConfig(array $config): void
+    {
+        if (!isset($config['warning_limit'], $config['block_limit'], $config['window'])) {
+            throw ThrottleConfigException::missingRequiredKeys();
+        }
+
+        $this->warningLimit = $this->validatePositiveInteger($config['warning_limit'], 'warning_limit');
+        $this->blockLimit = $this->validatePositiveInteger($config['block_limit'], 'block_limit');
+        $this->window = $this->validatePositiveInteger($config['window'], 'window');
+
+        if ($this->warningLimit >= $this->blockLimit) {
+            throw ThrottleConfigException::warningLimitTooHigh();
+        }
+
+        $this->penalties = $config['penalties'] ?? [];
+        $this->validatePenalties();
+
+        $this->recoveryPeriod = $this->validatePositiveInteger(
+            $config['recovery_period'] ?? $this->window,
+            'recovery_period'
+        );
+    }
+
+    private function validatePositiveInteger(int $value, string $key): int
+    {
+        if ($value <= 0) {
+            throw ThrottleConfigException::invalidValue($key, 'must be a positive integer');
+        }
+        return $value;
+    }
+
+    private function validatePenalties(): void
+    {
+        foreach ($this->penalties as $index => $penalty) {
+            if (!is_int($penalty) || $penalty <= 0) {
+                throw ThrottleConfigException::invalidValue(
+                    "penalties[$index]",
+                    'must be a positive integer'
+                );
+            }
+        }
+    }
+
+    public function getWarningLimit(): int
+    {
+        return $this->warningLimit;
+    }
+
+    public function getBlockLimit(): int
+    {
+        return $this->blockLimit;
+    }
+
+    public function getWindow(): int
+    {
+        return $this->window;
+    }
+
+    public function getRecoveryPeriod(): int
+    {
+        return $this->recoveryPeriod;
+    }
+
+    public function hasProgressivePenalties(): bool
+    {
+        return !empty($this->penalties);
+    }
+
+    public function getPenaltyDuration(int $violationNumber): int
+    {
+        if (empty($this->penalties)) {
+            return $this->window;
+        }
+
+        $penaltyIndex = min($violationNumber - 1, count($this->penalties) - 1);
+        return $this->penalties[$penaltyIndex];
+    }
+}

--- a/backend/src/SharedKernel/Domain/Throttle/ThrottleFactoryInterface.php
+++ b/backend/src/SharedKernel/Domain/Throttle/ThrottleFactoryInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Domain\Throttle;
+
+interface ThrottleFactoryInterface
+{
+    public function create(ThrottleConfig $config, string $name): ThrottleInterface;
+}

--- a/backend/src/SharedKernel/Domain/Throttle/ThrottleInterface.php
+++ b/backend/src/SharedKernel/Domain/Throttle/ThrottleInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Domain\Throttle;
+
+use SharedKernel\Domain\Throttle\Exceptions\ThrottleDriverException;
+
+interface ThrottleInterface
+{
+    /**
+     * Attempt to perform an action for the given identifier
+     * @param string $identifier The unique identifier (e.g., 'ip:192.168.1.1' or 'user:12345')
+     * @return ThrottleResult The result indicating if the action is allowed
+     * @throws ThrottleDriverException
+     */
+    public function attempt(string $identifier): ThrottleResult;
+
+    /**
+     * Clear all throttling state for the given identifier (complete reset/unblock)
+     * @param string $identifier The unique identifier to reset
+     * @throws ThrottleDriverException
+     */
+    public function clear(string $identifier): void;
+}

--- a/backend/src/SharedKernel/Domain/Throttle/ThrottleResolveResult.php
+++ b/backend/src/SharedKernel/Domain/Throttle/ThrottleResolveResult.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Domain\Throttle;
+
+final class ThrottleResolveResult
+{
+    private const DEFAULT_SCOPE = '__default__';
+
+    private ThrottleConfig $config;
+    private string $scope;
+
+    private function __construct(ThrottleConfig $config, string $scope)
+    {
+        $this->config = $config;
+        $this->scope = $scope;
+    }
+
+    public static function forCommand(ThrottleConfig $config, string $commandName): self
+    {
+        return new self($config, $commandName);
+    }
+
+    public static function forDefault(ThrottleConfig $config): self
+    {
+        return new self($config, self::DEFAULT_SCOPE);
+    }
+
+    public function getConfig(): ThrottleConfig
+    {
+        return $this->config;
+    }
+
+    public function getScope(): string
+    {
+        return $this->scope;
+    }
+}

--- a/backend/src/SharedKernel/Domain/Throttle/ThrottleResult.php
+++ b/backend/src/SharedKernel/Domain/Throttle/ThrottleResult.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Domain\Throttle;
+
+class ThrottleResult
+{
+    private bool $allowed;
+    private bool $warningTriggered;
+    private int $retryAfter;
+    private int $currentAttempts;
+
+    private function __construct(
+        bool $allowed,
+        bool $warningTriggered,
+        int $retryAfter,
+        int $currentAttempts
+    ) {
+        $this->allowed = $allowed;
+        $this->warningTriggered = $warningTriggered;
+        $this->retryAfter = $retryAfter;
+        $this->currentAttempts = $currentAttempts;
+    }
+
+    public static function allowed(int $currentAttempts): self
+    {
+        return new self(true, false, 0, $currentAttempts);
+    }
+
+    public static function warning(int $currentAttempts): self
+    {
+        return new self(true, true, 0, $currentAttempts);
+    }
+
+    public static function blocked(int $retryAfter, int $currentAttempts = 0): self
+    {
+        return new self(false, false, $retryAfter, $currentAttempts);
+    }
+
+    public function isAllowed(): bool
+    {
+        return $this->allowed;
+    }
+
+    public function isWarningTriggered(): bool
+    {
+        return $this->warningTriggered;
+    }
+
+    public function getRetryAfter(): int
+    {
+        return $this->retryAfter;
+    }
+
+    public function getCurrentAttempts(): int
+    {
+        return $this->currentAttempts;
+    }
+}

--- a/backend/src/SharedKernel/Infrastructure/CqrsMessageBus/Decorators/CommandThrottleDecorator.php
+++ b/backend/src/SharedKernel/Infrastructure/CqrsMessageBus/Decorators/CommandThrottleDecorator.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Infrastructure\CqrsMessageBus\Decorators;
+
+use SharedKernel\Application\CqrsMessageBus\Commands\CommandBusInterface;
+use SharedKernel\Application\CqrsMessageBus\Commands\CommandInterface;
+use SharedKernel\Application\Http\RequestContextInterface;
+use SharedKernel\Application\Throttle\ThrottleConfigResolverInterface;
+use SharedKernel\Domain\EventSystem\AsyncEventProcessorInterface;
+use SharedKernel\Domain\Logger\LoggerInterface;
+use SharedKernel\Domain\Security\SecurityContextInterface;
+use SharedKernel\Domain\Throttle\ThrottleFactoryInterface;
+
+final class CommandThrottleDecorator implements CommandBusInterface
+{
+    use ThrottleLogicTrait;
+
+    private CommandBusInterface $inner;
+    private ThrottleFactoryInterface $throttleFactory;
+    private ThrottleConfigResolverInterface $throttleConfig;
+    private SecurityContextInterface $securityContext;
+    private RequestContextInterface $requestContext;
+    private AsyncEventProcessorInterface $asyncEventProcessor;
+    private LoggerInterface $logger;
+
+    public function __construct(
+        CommandBusInterface $inner,
+        ThrottleFactoryInterface $throttleFactory,
+        ThrottleConfigResolverInterface $throttleConfig,
+        SecurityContextInterface $securityContext,
+        RequestContextInterface $requestContext,
+        AsyncEventProcessorInterface $asyncEventProcessor,
+        LoggerInterface $logger
+    ) {
+        $this->inner = $inner;
+        $this->throttleFactory = $throttleFactory;
+        $this->throttleConfig = $throttleConfig;
+        $this->securityContext = $securityContext;
+        $this->requestContext = $requestContext;
+        $this->asyncEventProcessor = $asyncEventProcessor;
+        $this->logger = $logger;
+    }
+
+    public function dispatch(CommandInterface $command): void
+    {
+        $this->activateThrottle(get_class($command), 'command');
+        $this->inner->dispatch($command);
+    }
+}

--- a/backend/src/SharedKernel/Infrastructure/CqrsMessageBus/Decorators/QueryThrottleDecorator.php
+++ b/backend/src/SharedKernel/Infrastructure/CqrsMessageBus/Decorators/QueryThrottleDecorator.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Infrastructure\CqrsMessageBus\Decorators;
+
+use SharedKernel\Application\CqrsMessageBus\Queries\QueryBusInterface;
+use SharedKernel\Application\CqrsMessageBus\Queries\QueryInterface;
+use SharedKernel\Application\CqrsMessageBus\Queries\QueryResponseInterface;
+use SharedKernel\Application\Http\RequestContextInterface;
+use SharedKernel\Application\Throttle\ThrottleConfigResolverInterface;
+use SharedKernel\Domain\EventSystem\AsyncEventProcessorInterface;
+use SharedKernel\Domain\Logger\LoggerInterface;
+use SharedKernel\Domain\Security\SecurityContextInterface;
+use SharedKernel\Domain\Throttle\ThrottleFactoryInterface;
+
+final class QueryThrottleDecorator implements QueryBusInterface
+{
+    use ThrottleLogicTrait;
+
+    private QueryBusInterface $inner;
+    private ThrottleFactoryInterface $throttleFactory;
+    private ThrottleConfigResolverInterface $throttleConfig;
+    private SecurityContextInterface $securityContext;
+    private RequestContextInterface $requestContext;
+    private AsyncEventProcessorInterface $asyncEventProcessor;
+    private LoggerInterface $logger;
+
+    public function __construct(
+        QueryBusInterface $inner,
+        ThrottleFactoryInterface $throttleFactory,
+        ThrottleConfigResolverInterface $throttleConfig,
+        SecurityContextInterface $securityContext,
+        RequestContextInterface $requestContext,
+        AsyncEventProcessorInterface $asyncEventProcessor,
+        LoggerInterface $logger
+    ) {
+        $this->inner = $inner;
+        $this->throttleFactory = $throttleFactory;
+        $this->throttleConfig = $throttleConfig;
+        $this->securityContext = $securityContext;
+        $this->requestContext = $requestContext;
+        $this->asyncEventProcessor = $asyncEventProcessor;
+        $this->logger = $logger;
+    }
+
+    public function dispatch(QueryInterface $query): QueryResponseInterface
+    {
+        $this->activateThrottle(get_class($query), 'query');
+
+        return $this->inner->dispatch($query);
+    }
+}

--- a/backend/src/SharedKernel/Infrastructure/CqrsMessageBus/Decorators/ThrottleLogicTrait.php
+++ b/backend/src/SharedKernel/Infrastructure/CqrsMessageBus/Decorators/ThrottleLogicTrait.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Infrastructure\CqrsMessageBus\Decorators;
+
+use SharedKernel\Domain\Throttle\Events\CqrsThrottleBlockedEvent;
+use SharedKernel\Domain\Throttle\Events\CqrsThrottleWarningEvent;
+use SharedKernel\Domain\Throttle\Exceptions\ThrottleDriverException;
+use SharedKernel\Domain\Throttle\Exceptions\ThrottleException;
+use Throwable;
+
+trait ThrottleLogicTrait
+{
+    private function activateThrottle(string $messageClass, string $messageType): void
+    {
+        $throttleException = null;
+
+        try {
+            $isAuthenticated = $this->securityContext->hasAuthenticatedUser();
+
+            if ($isAuthenticated) {
+                $user = $this->securityContext->getCurrentUser();
+                $userType = $user->getType();
+                $resolved = $this->throttleConfig->resolve($messageClass, $messageType, $userType);
+
+                if ($resolved === null) {
+                    return;
+                }
+
+                $identifier = $userType . ':' . $user->getId();
+            } else {
+                $ip = $this->requestContext->getClientIp();
+                $resolved = $this->throttleConfig->resolve($messageClass, $messageType, null);
+
+                if ($resolved === null) {
+                    return;
+                }
+
+                $identifier = 'ip:' . $ip;
+                $userType = null;
+            }
+
+            $config = $resolved->getConfig();
+            $scope = $resolved->getScope();
+            $clientIp = $this->requestContext->getClientIp();
+            $throttler = $this->throttleFactory->create($config, $scope);
+            $result = $throttler->attempt($identifier);
+
+            $shortName = substr(strrchr($messageClass, '\\'), 1) ?: $messageClass;
+
+            if ($result->isWarningTriggered() && $result->getCurrentAttempts() === $config->getWarningLimit()) {
+                $this->fireWarningEvent(
+                    $messageType,
+                    $shortName,
+                    $identifier,
+                    $config->getWarningLimit(),
+                    $clientIp,
+                    $userType
+                );
+            }
+
+            if (!$result->isAllowed()) {
+                $throttleException = ThrottleException::blockedIdentifier(
+                    $result->getRetryAfter(),
+                    $identifier
+                );
+
+                if ($result->getCurrentAttempts() === $config->getBlockLimit()) {
+                    $this->fireBlockedEvent(
+                        $messageType,
+                        $shortName,
+                        $identifier,
+                        $result->getRetryAfter(),
+                        $clientIp,
+                        $userType
+                    );
+                }
+            }
+        } catch (ThrottleDriverException $e) {
+            $this->logger->error("[THROTTLE] Driver connection failed - allowing $messageType");
+        }
+
+        if ($throttleException !== null) {
+            throw $throttleException;
+        }
+    }
+
+    private function fireWarningEvent(
+        string $messageType,
+        string $messageName,
+        string $identifier,
+        int $requestCount,
+        string $clientIp,
+        ?string $userType
+    ): void {
+        $this->logger->warning('[THROTTLE] Warning threshold reached', [
+            'message_type' => $messageType,
+            'message_class' => $messageName,
+            'identifier' => $identifier,
+            'request_count' => $requestCount,
+            'throttle_action' => 'warning_triggered',
+        ]);
+
+        try {
+            $event = CqrsThrottleWarningEvent::create(
+                $messageType,
+                $messageName,
+                $identifier,
+                $requestCount,
+                $clientIp,
+                $userType
+            );
+            $this->asyncEventProcessor->store($event);
+        } catch (Throwable $e) {
+            $this->logger->error('[THROTTLE] Failed to process warning event', [
+                'error' => $e->getMessage(),
+                'message_type' => $messageType,
+                'identifier' => $identifier,
+            ]);
+        }
+    }
+
+    private function fireBlockedEvent(
+        string $messageType,
+        string $messageName,
+        string $identifier,
+        int $retryAfter,
+        string $clientIp,
+        ?string $userType
+    ): void {
+        $this->logger->warning('[THROTTLE] Request blocked', [
+            'message_type' => $messageType,
+            'message_class' => $messageName,
+            'identifier' => $identifier,
+            'retry_after' => $retryAfter,
+            'throttle_action' => 'request_blocked',
+        ]);
+
+        try {
+            $event = CqrsThrottleBlockedEvent::create(
+                $messageType,
+                $messageName,
+                $identifier,
+                $retryAfter,
+                $clientIp,
+                $userType
+            );
+            $this->asyncEventProcessor->store($event);
+        } catch (Throwable $e) {
+            $this->logger->error('[THROTTLE] Failed to process blocked event', [
+                'error' => $e->getMessage(),
+                'message_type' => $messageType,
+                'identifier' => $identifier,
+            ]);
+        }
+    }
+}

--- a/backend/src/SharedKernel/Infrastructure/Redis/PhpRedisClient.php
+++ b/backend/src/SharedKernel/Infrastructure/Redis/PhpRedisClient.php
@@ -146,6 +146,15 @@ class PhpRedisClient implements RedisClientInterface
         }
     }
 
+    public function expire(string $key, int $ttl): bool
+    {
+        try {
+            return $this->client->expire($key, $ttl);
+        } catch (RedisException $e) {
+            throw RedisConnectionException::operationFailed('EXPIRE', $e->getMessage());
+        }
+    }
+
     public function setnx(string $key, string $value, int $ttl = 0): bool
     {
         try {

--- a/backend/src/SharedKernel/Infrastructure/Redis/ReadWriteRedisClient.php
+++ b/backend/src/SharedKernel/Infrastructure/Redis/ReadWriteRedisClient.php
@@ -110,6 +110,11 @@ class ReadWriteRedisClient implements RedisClientInterface
         return $this->writeClient->incr($key);
     }
 
+    public function expire(string $key, int $ttl): bool
+    {
+        return $this->writeClient->expire($key, $ttl);
+    }
+
     public function setnx(string $key, string $value, int $ttl = 0): bool
     {
         return $this->writeClient->setnx($key, $value, $ttl);

--- a/backend/src/SharedKernel/Infrastructure/Throttle/NullThrottler.php
+++ b/backend/src/SharedKernel/Infrastructure/Throttle/NullThrottler.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Infrastructure\Throttle;
+
+use SharedKernel\Domain\Throttle\ThrottleInterface;
+use SharedKernel\Domain\Throttle\ThrottleResult;
+
+final class NullThrottler implements ThrottleInterface
+{
+    public function attempt(string $identifier): ThrottleResult
+    {
+        return ThrottleResult::allowed(0);
+    }
+
+    public function clear(string $identifier): void
+    {
+    }
+}

--- a/backend/src/SharedKernel/Infrastructure/Throttle/NullThrottlerFactory.php
+++ b/backend/src/SharedKernel/Infrastructure/Throttle/NullThrottlerFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Infrastructure\Throttle;
+
+use SharedKernel\Domain\Throttle\ThrottleConfig;
+use SharedKernel\Domain\Throttle\ThrottleFactoryInterface;
+use SharedKernel\Domain\Throttle\ThrottleInterface;
+
+final class NullThrottlerFactory implements ThrottleFactoryInterface
+{
+    public function create(ThrottleConfig $config, string $name): ThrottleInterface
+    {
+        return new NullThrottler();
+    }
+}

--- a/backend/src/SharedKernel/Infrastructure/Throttle/RedisThrottler.php
+++ b/backend/src/SharedKernel/Infrastructure/Throttle/RedisThrottler.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Infrastructure\Throttle;
+
+use SharedKernel\Domain\Redis\Exceptions\RedisConnectionException;
+use SharedKernel\Domain\Redis\RedisClientInterface;
+use SharedKernel\Domain\Throttle\Exceptions\ThrottleDriverException;
+use SharedKernel\Domain\Throttle\ThrottleConfig;
+use SharedKernel\Domain\Throttle\ThrottleInterface;
+use SharedKernel\Domain\Throttle\ThrottleResult;
+
+class RedisThrottler implements ThrottleInterface
+{
+    private const REDIS_KEY_PREFIX = 'throttle';
+
+    protected RedisClientInterface $redis;
+    protected ThrottleConfig $config;
+    protected string $type;
+
+    public function __construct(RedisClientInterface $redis, ThrottleConfig $config, string $type)
+    {
+        $this->redis = $redis;
+        $this->config = $config;
+        $this->type = $type;
+    }
+
+    public function attempt(string $identifier): ThrottleResult
+    {
+        try {
+            if ($this->isBlocked($identifier)) {
+                $retryAfter = $this->getBlockedUntil($identifier) - time();
+                return ThrottleResult::blocked(max(0, $retryAfter));
+            }
+
+            // Generate time window key
+            $windowId = (int) floor(time() / $this->config->getWindow());
+            $countKey = self::REDIS_KEY_PREFIX . ":$this->type:$identifier:window:$windowId";
+
+            // Increment counter atomically — incr creates the key if missing
+            $count = $this->redis->incr($countKey);
+            if ($count === 1) {
+                // First request in this window — set TTL
+                $this->redis->expire($countKey, $this->config->getWindow());
+            }
+
+            if ($count >= $this->config->getBlockLimit()) {
+                $retryAfter = $this->blockIdentifier($identifier);
+                return ThrottleResult::blocked($retryAfter, $count);
+            }
+
+            if ($count >= $this->config->getWarningLimit()) {
+                return ThrottleResult::warning($count);
+            }
+
+            return ThrottleResult::allowed($count);
+        } catch (RedisConnectionException $e) {
+            throw new ThrottleDriverException($e->getMessage(), $e);
+        }
+    }
+
+    public function clear(string $identifier): void
+    {
+        try {
+            // Clear all throttle-related keys for the identifier
+            $baseKey = self::REDIS_KEY_PREFIX . ":$this->type:$identifier";
+
+            // Get all possible keys to clear
+            $keysToDelete = [];
+
+            // Current and recent window keys (clear last few windows to be safe)
+            $currentWindowId = (int) floor(time() / $this->config->getWindow());
+            for ($i = 0; $i <= 2; $i++) {
+                $windowKey = "$baseKey:window:" . ($currentWindowId - $i);
+                $keysToDelete[] = $windowKey;
+            }
+
+            // Violation and blocked keys
+            $keysToDelete[] = "$baseKey:violations";
+            $keysToDelete[] = "$baseKey:blocked";
+
+            // Delete all keys
+            foreach ($keysToDelete as $key) {
+                $this->redis->del($key);
+            }
+        } catch (RedisConnectionException $e) {
+            throw new ThrottleDriverException($e->getMessage(), $e);
+        }
+    }
+
+    private function isBlocked(string $identifier): bool
+    {
+        $blockedKey = self::REDIS_KEY_PREFIX . ":$this->type:$identifier:blocked";
+        $blockedUntil = $this->redis->getMaster($blockedKey);
+
+        return $blockedUntil !== null && (int) $blockedUntil > time();
+    }
+
+    private function getBlockedUntil(string $identifier): int
+    {
+        $blockedKey = self::REDIS_KEY_PREFIX . ":$this->type:$identifier:blocked";
+        $blockedUntil = $this->redis->getMaster($blockedKey);
+
+        return $blockedUntil !== null ? (int) $blockedUntil : 0;
+    }
+
+    private function blockIdentifier(string $identifier): int
+    {
+        $blockDuration = $this->getBlockDuration($identifier);
+        $blockedUntil = time() + $blockDuration;
+
+        $blockedKey = self::REDIS_KEY_PREFIX . ":$this->type:$identifier:blocked";
+        $this->redis->set($blockedKey, (string) $blockedUntil, $blockDuration);
+
+        return $blockDuration;
+    }
+
+    private function getBlockDuration(string $identifier): int
+    {
+        if (!$this->config->hasProgressivePenalties()) {
+            return $this->config->getWindow();
+        }
+
+        $violations = $this->incrementViolations($identifier);
+        return $this->config->getPenaltyDuration($violations);
+    }
+
+    private function incrementViolations(string $identifier): int
+    {
+        $violationKey = self::REDIS_KEY_PREFIX . ":$this->type:$identifier:violations";
+
+        $violations = $this->redis->incr($violationKey);
+        if ($violations === 1) {
+            $this->redis->expire($violationKey, $this->config->getRecoveryPeriod());
+        }
+
+        return $violations;
+    }
+}

--- a/backend/src/SharedKernel/Infrastructure/Throttle/RedisThrottlerFactory.php
+++ b/backend/src/SharedKernel/Infrastructure/Throttle/RedisThrottlerFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Infrastructure\Throttle;
+
+use SharedKernel\Domain\Redis\RedisClientInterface;
+use SharedKernel\Domain\Throttle\ThrottleConfig;
+use SharedKernel\Domain\Throttle\ThrottleFactoryInterface;
+use SharedKernel\Domain\Throttle\ThrottleInterface;
+
+final class RedisThrottlerFactory implements ThrottleFactoryInterface
+{
+    private RedisClientInterface $redisClient;
+
+    public function __construct(RedisClientInterface $redisClient)
+    {
+        $this->redisClient = $redisClient;
+    }
+
+    public function create(ThrottleConfig $config, string $name): ThrottleInterface
+    {
+        return new RedisThrottler($this->redisClient, $config, $name);
+    }
+}

--- a/backend/src/SharedKernel/Infrastructure/Throttle/ThrottleConfigDefaults.php
+++ b/backend/src/SharedKernel/Infrastructure/Throttle/ThrottleConfigDefaults.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Infrastructure\Throttle;
+
+use SharedKernel\Domain\Security\UserType;
+
+final class ThrottleConfigDefaults
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function load(): array
+    {
+        return [
+            'defaults' => [
+                UserType::ADMIN => null,
+                UserType::SYSTEM => null,
+                UserType::PARTNER => [
+                    'warning_limit' => 100,
+                    'block_limit' => 200,
+                    'window' => 60,
+                    'penalties' => [300, 3600],
+                    'recovery_period' => 3600,
+                ],
+                UserType::CUSTOMER => [
+                    'warning_limit' => 30,
+                    'block_limit' => 50,
+                    'window' => 60,
+                    'penalties' => [300, 3600, 10800],
+                    'recovery_period' => 10800,
+                ],
+                // No anonymous default — broad anonymous throttling is handled at the HTTP layer.
+                // Per-command anonymous overrides can still be added in the 'commands' section.
+            ],
+            'commands' => [],
+            'queries' => [],
+            'excluded' => [],
+        ];
+    }
+}

--- a/backend/src/SharedKernel/Infrastructure/Throttle/ThrottleConfigResolver.php
+++ b/backend/src/SharedKernel/Infrastructure/Throttle/ThrottleConfigResolver.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Infrastructure\Throttle;
+
+use SharedKernel\Application\Throttle\ThrottleConfigResolverInterface;
+use SharedKernel\Domain\Throttle\ThrottleConfig;
+use SharedKernel\Domain\Throttle\ThrottleResolveResult;
+
+final class ThrottleConfigResolver implements ThrottleConfigResolverInterface
+{
+    /** @var array<string, mixed> */
+    private array $config;
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function __construct(array $config)
+    {
+        $this->config = $config;
+    }
+
+    public function resolve(string $messageClass, string $messageType, ?string $userType): ?ThrottleResolveResult
+    {
+        // 1. Excluded?
+        if ($this->isExcluded($messageClass)) {
+            return null;
+        }
+
+        $key = $userType ?? 'anonymous';
+        $section = $messageType === 'command' ? 'commands' : 'queries';
+        $messageConfig = $this->config[$section][$messageClass] ?? null;
+        $shortName = substr(strrchr($messageClass, '\\'), 1) ?: $messageClass;
+
+        if ($messageConfig !== null) {
+            // 2. Exact user type match in per-message config
+            if (isset($messageConfig[$key]) && is_array($messageConfig[$key])) {
+                return ThrottleResolveResult::forCommand(ThrottleConfig::fromArray($messageConfig[$key]), $shortName);
+            }
+
+            // 3. Catch-all 'authenticated' key for any authenticated user
+            if (
+                $key !== 'anonymous'
+                && isset($messageConfig['authenticated'])
+                && is_array($messageConfig['authenticated'])
+            ) {
+                return ThrottleResolveResult::forCommand(
+                    ThrottleConfig::fromArray($messageConfig['authenticated']),
+                    $shortName
+                );
+            }
+
+            // 4. Flat config (has 'warning_limit' at top level)
+            if (isset($messageConfig['warning_limit'])) {
+                return ThrottleResolveResult::forCommand(ThrottleConfig::fromArray($messageConfig), $shortName);
+            }
+        }
+
+        // 5. Default for this user type
+        if (array_key_exists($key, $this->config['defaults'] ?? [])) {
+            $default = $this->config['defaults'][$key];
+
+            if ($default === null) {
+                return null;
+            }
+
+            return ThrottleResolveResult::forDefault(ThrottleConfig::fromArray($default));
+        }
+
+        // 6. No match
+        return null;
+    }
+
+    private function isExcluded(string $messageClass): bool
+    {
+        return in_array($messageClass, $this->config['excluded'] ?? [], true);
+    }
+}

--- a/backend/src/SharedKernel/Infrastructure/Throttle/ThrottleDriverFactory.php
+++ b/backend/src/SharedKernel/Infrastructure/Throttle/ThrottleDriverFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Infrastructure\Throttle;
+
+use SharedKernel\Domain\Environment;
+use SharedKernel\Domain\Redis\RedisClientInterface;
+use SharedKernel\Domain\Throttle\ThrottleFactoryInterface;
+
+final class ThrottleDriverFactory
+{
+    private Environment $environment;
+    private RedisClientInterface $redisClient;
+
+    public function __construct(Environment $environment, RedisClientInterface $redisClient)
+    {
+        $this->environment = $environment;
+        $this->redisClient = $redisClient;
+    }
+
+    public function __invoke(): ThrottleFactoryInterface
+    {
+        if ($this->environment->isProduction() || $this->environment->isStaging()) {
+            return new RedisThrottlerFactory($this->redisClient);
+        }
+
+        return new NullThrottlerFactory();
+    }
+}

--- a/backend/tests/Fixtures/SharedKernel/Http/StubRequestContext.php
+++ b/backend/tests/Fixtures/SharedKernel/Http/StubRequestContext.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\SharedKernel\Http;
+
+use SharedKernel\Application\Http\RequestContextInterface;
+
+final class StubRequestContext implements RequestContextInterface
+{
+    private string $clientIp;
+
+    public function __construct(string $clientIp = '127.0.0.1')
+    {
+        $this->clientIp = $clientIp;
+    }
+
+    public function getClientIp(): string
+    {
+        return $this->clientIp;
+    }
+}

--- a/backend/tests/Fixtures/SharedKernel/Security/StubSecurityContext.php
+++ b/backend/tests/Fixtures/SharedKernel/Security/StubSecurityContext.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\SharedKernel\Security;
+
+use SharedKernel\Domain\Security\AuthenticatedUser;
+use SharedKernel\Domain\Security\SecurityContextInterface;
+
+final class StubSecurityContext implements SecurityContextInterface
+{
+    private ?AuthenticatedUser $user;
+
+    public function __construct(?AuthenticatedUser $user = null)
+    {
+        $this->user = $user;
+    }
+
+    public function getCurrentUser(): ?AuthenticatedUser
+    {
+        return $this->user;
+    }
+
+    public function setCurrentUser(AuthenticatedUser $user): void
+    {
+        $this->user = $user;
+    }
+
+    public function hasAuthenticatedUser(): bool
+    {
+        return $this->user !== null;
+    }
+
+    public function clearUser(): void
+    {
+        $this->user = null;
+    }
+}

--- a/backend/tests/Unit/SharedKernel/Domain/Security/AuthenticatedUserTest.php
+++ b/backend/tests/Unit/SharedKernel/Domain/Security/AuthenticatedUserTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\SharedKernel\Domain\Security;
+
+use PHPUnit\Framework\TestCase;
+use SharedKernel\Domain\Security\AuthenticatedUser;
+use SharedKernel\Domain\Security\UserType;
+
+class AuthenticatedUserTest extends TestCase
+{
+    public function testConstructionWithExplicitType(): void
+    {
+        $user = new AuthenticatedUser('42', 'admin@example.com', ['admin'], UserType::ADMIN);
+
+        $this->assertSame('42', $user->getId());
+        $this->assertSame('admin@example.com', $user->getEmail());
+        $this->assertSame(['admin'], $user->getRoles());
+        $this->assertSame(UserType::ADMIN, $user->getType());
+    }
+
+    public function testConstructionWithoutTypeDefaultsToCustomer(): void
+    {
+        $user = new AuthenticatedUser('1', 'user@example.com', ['user']);
+
+        $this->assertSame(UserType::CUSTOMER, $user->getType());
+    }
+
+    public function testConstructionWithPartnerType(): void
+    {
+        $user = new AuthenticatedUser('10', 'partner@example.com', ['partner'], UserType::PARTNER);
+
+        $this->assertSame(UserType::PARTNER, $user->getType());
+    }
+
+    public function testConstructionWithCustomerType(): void
+    {
+        $user = new AuthenticatedUser('20', 'customer@example.com', [], UserType::CUSTOMER);
+
+        $this->assertSame(UserType::CUSTOMER, $user->getType());
+    }
+
+    public function testConstructionWithMinimalArguments(): void
+    {
+        $user = new AuthenticatedUser('1', 'test@example.com');
+
+        $this->assertSame('1', $user->getId());
+        $this->assertSame('test@example.com', $user->getEmail());
+        $this->assertSame([], $user->getRoles());
+        $this->assertSame(UserType::CUSTOMER, $user->getType());
+    }
+}

--- a/backend/tests/Unit/SharedKernel/Domain/Security/UserTypeTest.php
+++ b/backend/tests/Unit/SharedKernel/Domain/Security/UserTypeTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\SharedKernel\Domain\Security;
+
+use PHPUnit\Framework\TestCase;
+use SharedKernel\Domain\Security\UserType;
+
+class UserTypeTest extends TestCase
+{
+    public function testIsValidReturnsTrueForAllDefinedTypes(): void
+    {
+        $this->assertTrue(UserType::isValid(UserType::ADMIN));
+        $this->assertTrue(UserType::isValid(UserType::PARTNER));
+        $this->assertTrue(UserType::isValid(UserType::CUSTOMER));
+        $this->assertTrue(UserType::isValid(UserType::SYSTEM));
+        $this->assertTrue(UserType::isValid(UserType::ANONYMOUS));
+    }
+
+    public function testIsValidReturnsFalseForUnknownType(): void
+    {
+        $this->assertFalse(UserType::isValid('superadmin'));
+        $this->assertFalse(UserType::isValid(''));
+        $this->assertFalse(UserType::isValid('ADMIN'));
+    }
+
+    public function testGetAllReturnsAllDefinedTypes(): void
+    {
+        $all = UserType::getAll();
+
+        $this->assertCount(5, $all);
+        $this->assertContains(UserType::ADMIN, $all);
+        $this->assertContains(UserType::PARTNER, $all);
+        $this->assertContains(UserType::CUSTOMER, $all);
+        $this->assertContains(UserType::SYSTEM, $all);
+        $this->assertContains(UserType::ANONYMOUS, $all);
+    }
+
+    public function testConstantValues(): void
+    {
+        $this->assertSame('admin', UserType::ADMIN);
+        $this->assertSame('partner', UserType::PARTNER);
+        $this->assertSame('customer', UserType::CUSTOMER);
+        $this->assertSame('system', UserType::SYSTEM);
+        $this->assertSame('anonymous', UserType::ANONYMOUS);
+    }
+}

--- a/backend/tests/Unit/SharedKernel/Domain/Throttle/Events/CqrsThrottleBlockedEventTest.php
+++ b/backend/tests/Unit/SharedKernel/Domain/Throttle/Events/CqrsThrottleBlockedEventTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\SharedKernel\Domain\Throttle\Events;
+
+use PHPUnit\Framework\TestCase;
+use SharedKernel\Domain\Security\UserType;
+use SharedKernel\Domain\Throttle\Events\CqrsThrottleBlockedEvent;
+
+class CqrsThrottleBlockedEventTest extends TestCase
+{
+    public function testCreateWithAllFields(): void
+    {
+        $event = CqrsThrottleBlockedEvent::create(
+            'command',
+            'CreateOrderCommand',
+            'user:42',
+            300,
+            '192.168.1.100',
+            UserType::CUSTOMER
+        );
+
+        $this->assertSame('command', $event->getMessageType());
+        $this->assertSame('CreateOrderCommand', $event->getMessageClass());
+        $this->assertSame('user:42', $event->getIdentifier());
+        $this->assertSame(300, $event->getRetryAfter());
+        $this->assertSame('192.168.1.100', $event->getClientIp());
+        $this->assertSame(UserType::CUSTOMER, $event->getUserType());
+    }
+
+    public function testCreateWithNullUserTypeForAnonymous(): void
+    {
+        $event = CqrsThrottleBlockedEvent::create(
+            'query',
+            'SearchQuery',
+            'ip:10.0.0.1',
+            600,
+            '10.0.0.1',
+            null
+        );
+
+        $this->assertNull($event->getUserType());
+        $this->assertSame('10.0.0.1', $event->getClientIp());
+    }
+
+    public function testSerializeDeserializeRoundtrip(): void
+    {
+        $event = CqrsThrottleBlockedEvent::create(
+            'command',
+            'ContactFormCommand',
+            'ip:192.168.1.50',
+            3600,
+            '192.168.1.50',
+            null
+        );
+
+        $serialized = $event->serialize();
+        $restored = CqrsThrottleBlockedEvent::fromPayload($serialized);
+
+        $this->assertSame($event->getMessageType(), $restored->getMessageType());
+        $this->assertSame($event->getMessageClass(), $restored->getMessageClass());
+        $this->assertSame($event->getIdentifier(), $restored->getIdentifier());
+        $this->assertSame($event->getRetryAfter(), $restored->getRetryAfter());
+        $this->assertSame($event->getClientIp(), $restored->getClientIp());
+        $this->assertSame($event->getUserType(), $restored->getUserType());
+    }
+
+    public function testFromPayloadWithMissingNewFieldsBackwardCompatible(): void
+    {
+        $payload = [
+            'message_type' => 'command',
+            'message_class' => 'OldCommand',
+            'identifier' => 'user:1',
+            'retry_after' => 300,
+        ];
+
+        $event = CqrsThrottleBlockedEvent::fromPayload($payload);
+
+        $this->assertSame('', $event->getClientIp());
+        $this->assertNull($event->getUserType());
+    }
+}

--- a/backend/tests/Unit/SharedKernel/Domain/Throttle/Events/CqrsThrottleWarningEventTest.php
+++ b/backend/tests/Unit/SharedKernel/Domain/Throttle/Events/CqrsThrottleWarningEventTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\SharedKernel\Domain\Throttle\Events;
+
+use PHPUnit\Framework\TestCase;
+use SharedKernel\Domain\Security\UserType;
+use SharedKernel\Domain\Throttle\Events\CqrsThrottleWarningEvent;
+
+class CqrsThrottleWarningEventTest extends TestCase
+{
+    public function testCreateWithAllFields(): void
+    {
+        $event = CqrsThrottleWarningEvent::create(
+            'command',
+            'CreateOrderCommand',
+            'user:42',
+            25,
+            '192.168.1.100',
+            UserType::CUSTOMER
+        );
+
+        $this->assertSame('command', $event->getMessageType());
+        $this->assertSame('CreateOrderCommand', $event->getMessageClass());
+        $this->assertSame('user:42', $event->getIdentifier());
+        $this->assertSame(25, $event->getRequestCount());
+        $this->assertSame('192.168.1.100', $event->getClientIp());
+        $this->assertSame(UserType::CUSTOMER, $event->getUserType());
+    }
+
+    public function testCreateWithNullUserTypeForAnonymous(): void
+    {
+        $event = CqrsThrottleWarningEvent::create(
+            'query',
+            'SearchQuery',
+            'ip:10.0.0.1',
+            15,
+            '10.0.0.1',
+            null
+        );
+
+        $this->assertNull($event->getUserType());
+        $this->assertSame('10.0.0.1', $event->getClientIp());
+    }
+
+    public function testSerializeDeserializeRoundtrip(): void
+    {
+        $event = CqrsThrottleWarningEvent::create(
+            'command',
+            'ContactFormCommand',
+            'ip:192.168.1.50',
+            18,
+            '192.168.1.50',
+            null
+        );
+
+        $serialized = $event->serialize();
+        $restored = CqrsThrottleWarningEvent::fromPayload($serialized);
+
+        $this->assertSame($event->getMessageType(), $restored->getMessageType());
+        $this->assertSame($event->getMessageClass(), $restored->getMessageClass());
+        $this->assertSame($event->getIdentifier(), $restored->getIdentifier());
+        $this->assertSame($event->getRequestCount(), $restored->getRequestCount());
+        $this->assertSame($event->getClientIp(), $restored->getClientIp());
+        $this->assertSame($event->getUserType(), $restored->getUserType());
+    }
+
+    public function testFromPayloadWithMissingNewFieldsBackwardCompatible(): void
+    {
+        $payload = [
+            'message_type' => 'command',
+            'message_class' => 'OldCommand',
+            'identifier' => 'user:1',
+            'request_count' => 10,
+        ];
+
+        $event = CqrsThrottleWarningEvent::fromPayload($payload);
+
+        $this->assertSame('', $event->getClientIp());
+        $this->assertNull($event->getUserType());
+    }
+}

--- a/backend/tests/Unit/SharedKernel/Infrastructure/CqrsMessageBus/Decorators/CommandThrottleDecoratorTest.php
+++ b/backend/tests/Unit/SharedKernel/Infrastructure/CqrsMessageBus/Decorators/CommandThrottleDecoratorTest.php
@@ -1,0 +1,282 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\SharedKernel\Infrastructure\CqrsMessageBus\Decorators;
+
+use PHPUnit\Framework\TestCase;
+use SharedKernel\Application\CqrsMessageBus\Commands\CommandBusInterface;
+use SharedKernel\Application\Throttle\ThrottleConfigResolverInterface;
+use SharedKernel\Domain\EventSystem\AsyncEventProcessorInterface;
+use SharedKernel\Domain\Logger\LoggerInterface;
+use SharedKernel\Domain\Throttle\Exceptions\ThrottleDriverException;
+use SharedKernel\Domain\Security\AuthenticatedUser;
+use SharedKernel\Domain\Security\UserType;
+use SharedKernel\Domain\Throttle\Exceptions\ThrottleException;
+use SharedKernel\Domain\Throttle\ThrottleConfig;
+use SharedKernel\Domain\Throttle\ThrottleFactoryInterface;
+use SharedKernel\Domain\Throttle\ThrottleResolveResult;
+use SharedKernel\Domain\Throttle\ThrottleInterface;
+use SharedKernel\Domain\Throttle\ThrottleResult;
+use SharedKernel\Infrastructure\CqrsMessageBus\Decorators\CommandThrottleDecorator;
+use Tests\Fixtures\SharedKernel\CqrsMessageBus\TestCommand;
+use Tests\Fixtures\SharedKernel\Http\StubRequestContext;
+use Tests\Fixtures\SharedKernel\Security\StubSecurityContext;
+
+class CommandThrottleDecoratorTest extends TestCase
+{
+    private function createConfig(): ThrottleConfig
+    {
+        return ThrottleConfig::fromArray([
+            'warning_limit' => 20,
+            'block_limit' => 30,
+            'window' => 60,
+        ]);
+    }
+
+    private function createDecorator(
+        CommandBusInterface $inner,
+        ThrottleConfigResolverInterface $throttleConfig,
+        StubSecurityContext $securityContext,
+        ?ThrottleFactoryInterface $throttleFactory = null,
+        ?AsyncEventProcessorInterface $asyncEventProcessor = null,
+        ?LoggerInterface $logger = null,
+        ?StubRequestContext $requestContext = null
+    ): CommandThrottleDecorator {
+        return new CommandThrottleDecorator(
+            $inner,
+            $throttleFactory ?? $this->createMock(ThrottleFactoryInterface::class),
+            $throttleConfig,
+            $securityContext,
+            $requestContext ?? new StubRequestContext('192.168.1.1'),
+            $asyncEventProcessor ?? $this->createMock(AsyncEventProcessorInterface::class),
+            $logger ?? $this->createMock(LoggerInterface::class)
+        );
+    }
+
+    public function testAuthenticatedUserAllowedDispatchesCommand(): void
+    {
+        $inner = $this->createMock(CommandBusInterface::class);
+        $inner->expects($this->once())->method('dispatch');
+
+        $throttleConfig = $this->createMock(ThrottleConfigResolverInterface::class);
+        $throttleConfig->method('resolve')->willReturn(ThrottleResolveResult::forDefault($this->createConfig()));
+
+        $throttler = $this->createMock(ThrottleInterface::class);
+        $throttler->method('attempt')->willReturn(ThrottleResult::allowed(5));
+
+        $factory = $this->createMock(ThrottleFactoryInterface::class);
+        $factory->method('create')->willReturn($throttler);
+
+        $user = new AuthenticatedUser('42', 'user@example.com', ['user'], UserType::CUSTOMER);
+        $securityContext = new StubSecurityContext($user);
+
+        $decorator = $this->createDecorator($inner, $throttleConfig, $securityContext, $factory);
+        $decorator->dispatch(new TestCommand('test'));
+    }
+
+    public function testAuthenticatedUserBlockedThrowsException(): void
+    {
+        $inner = $this->createMock(CommandBusInterface::class);
+        $inner->expects($this->never())->method('dispatch');
+
+        $throttleConfig = $this->createMock(ThrottleConfigResolverInterface::class);
+        $throttleConfig->method('resolve')->willReturn(ThrottleResolveResult::forDefault($this->createConfig()));
+
+        $throttler = $this->createMock(ThrottleInterface::class);
+        $throttler->method('attempt')->willReturn(ThrottleResult::blocked(300));
+
+        $factory = $this->createMock(ThrottleFactoryInterface::class);
+        $factory->method('create')->willReturn($throttler);
+
+        $user = new AuthenticatedUser('42', 'user@example.com', ['user'], UserType::CUSTOMER);
+        $securityContext = new StubSecurityContext($user);
+
+        $decorator = $this->createDecorator($inner, $throttleConfig, $securityContext, $factory);
+
+        $this->expectException(ThrottleException::class);
+        $decorator->dispatch(new TestCommand('test'));
+    }
+
+    public function testAdminExemptDispatchesWithoutThrottle(): void
+    {
+        $inner = $this->createMock(CommandBusInterface::class);
+        $inner->expects($this->once())->method('dispatch');
+
+        $throttleConfig = $this->createMock(ThrottleConfigResolverInterface::class);
+        $throttleConfig->method('resolve')->willReturn(null);
+
+        $factory = $this->createMock(ThrottleFactoryInterface::class);
+        $factory->expects($this->never())->method('create');
+
+        $user = new AuthenticatedUser('1', 'admin@example.com', ['admin'], UserType::ADMIN);
+        $securityContext = new StubSecurityContext($user);
+
+        $decorator = $this->createDecorator($inner, $throttleConfig, $securityContext, $factory);
+        $decorator->dispatch(new TestCommand('test'));
+    }
+
+    public function testAnonymousUserAllowedDispatchesCommand(): void
+    {
+        $inner = $this->createMock(CommandBusInterface::class);
+        $inner->expects($this->once())->method('dispatch');
+
+        $throttleConfig = $this->createMock(ThrottleConfigResolverInterface::class);
+        $throttleConfig->method('resolve')
+            ->with(TestCommand::class, 'command', null)
+            ->willReturn(ThrottleResolveResult::forDefault($this->createConfig()));
+
+        $throttler = $this->createMock(ThrottleInterface::class);
+        $throttler->method('attempt')
+            ->with('ip:10.0.0.1')
+            ->willReturn(ThrottleResult::allowed(3));
+
+        $factory = $this->createMock(ThrottleFactoryInterface::class);
+        $factory->method('create')->willReturn($throttler);
+
+        $securityContext = new StubSecurityContext(null);
+        $requestContext = new StubRequestContext('10.0.0.1');
+
+        $decorator = $this->createDecorator(
+            $inner,
+            $throttleConfig,
+            $securityContext,
+            $factory,
+            null,
+            null,
+            $requestContext
+        );
+        $decorator->dispatch(new TestCommand('test'));
+    }
+
+    public function testAnonymousUserBlockedThrowsException(): void
+    {
+        $inner = $this->createMock(CommandBusInterface::class);
+        $inner->expects($this->never())->method('dispatch');
+
+        $throttleConfig = $this->createMock(ThrottleConfigResolverInterface::class);
+        $throttleConfig->method('resolve')->willReturn(ThrottleResolveResult::forDefault($this->createConfig()));
+
+        $throttler = $this->createMock(ThrottleInterface::class);
+        $throttler->method('attempt')->willReturn(ThrottleResult::blocked(600));
+
+        $factory = $this->createMock(ThrottleFactoryInterface::class);
+        $factory->method('create')->willReturn($throttler);
+
+        $securityContext = new StubSecurityContext(null);
+
+        $decorator = $this->createDecorator($inner, $throttleConfig, $securityContext, $factory);
+
+        $this->expectException(ThrottleException::class);
+        $decorator->dispatch(new TestCommand('test'));
+    }
+
+    public function testExcludedCommandDispatchesWithoutThrottle(): void
+    {
+        $inner = $this->createMock(CommandBusInterface::class);
+        $inner->expects($this->once())->method('dispatch');
+
+        $throttleConfig = $this->createMock(ThrottleConfigResolverInterface::class);
+        $throttleConfig->method('resolve')->willReturn(null);
+
+        $factory = $this->createMock(ThrottleFactoryInterface::class);
+        $factory->expects($this->never())->method('create');
+
+        $securityContext = new StubSecurityContext(null);
+
+        $decorator = $this->createDecorator($inner, $throttleConfig, $securityContext, $factory);
+        $decorator->dispatch(new TestCommand('test'));
+    }
+
+    public function testRedisConnectionFailureAllowsThrough(): void
+    {
+        $inner = $this->createMock(CommandBusInterface::class);
+        $inner->expects($this->once())->method('dispatch');
+
+        $throttleConfig = $this->createMock(ThrottleConfigResolverInterface::class);
+        $throttleConfig->method('resolve')->willReturn(ThrottleResolveResult::forDefault($this->createConfig()));
+
+        $throttler = $this->createMock(ThrottleInterface::class);
+        $throttler->method('attempt')->willThrowException(new ThrottleDriverException('Connection refused'));
+
+        $factory = $this->createMock(ThrottleFactoryInterface::class);
+        $factory->method('create')->willReturn($throttler);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('error');
+
+        $user = new AuthenticatedUser('42', 'user@example.com', ['user'], UserType::CUSTOMER);
+        $securityContext = new StubSecurityContext($user);
+
+        $decorator = $this->createDecorator(
+            $inner,
+            $throttleConfig,
+            $securityContext,
+            $factory,
+            null,
+            $logger
+        );
+        $decorator->dispatch(new TestCommand('test'));
+    }
+
+    public function testWarningThresholdFiresEventAndStillDispatches(): void
+    {
+        $inner = $this->createMock(CommandBusInterface::class);
+        $inner->expects($this->once())->method('dispatch');
+
+        $config = $this->createConfig();
+
+        $throttleConfig = $this->createMock(ThrottleConfigResolverInterface::class);
+        $throttleConfig->method('resolve')->willReturn(ThrottleResolveResult::forDefault($config));
+
+        $throttler = $this->createMock(ThrottleInterface::class);
+        $throttler->method('attempt')->willReturn(ThrottleResult::warning($config->getWarningLimit()));
+
+        $factory = $this->createMock(ThrottleFactoryInterface::class);
+        $factory->method('create')->willReturn($throttler);
+
+        $asyncProcessor = $this->createMock(AsyncEventProcessorInterface::class);
+        $asyncProcessor->expects($this->once())->method('store');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('warning');
+
+        $user = new AuthenticatedUser('42', 'user@example.com', ['user'], UserType::CUSTOMER);
+        $securityContext = new StubSecurityContext($user);
+
+        $decorator = $this->createDecorator(
+            $inner,
+            $throttleConfig,
+            $securityContext,
+            $factory,
+            $asyncProcessor,
+            $logger
+        );
+        $decorator->dispatch(new TestCommand('test'));
+    }
+
+    public function testResolvesIdentifierAsUserIdForAuthenticated(): void
+    {
+        $inner = $this->createMock(CommandBusInterface::class);
+
+        $throttleConfig = $this->createMock(ThrottleConfigResolverInterface::class);
+        $throttleConfig->method('resolve')
+            ->with(TestCommand::class, 'command', UserType::PARTNER)
+            ->willReturn(ThrottleResolveResult::forDefault($this->createConfig()));
+
+        $throttler = $this->createMock(ThrottleInterface::class);
+        $throttler->expects($this->once())
+            ->method('attempt')
+            ->with('partner:99')
+            ->willReturn(ThrottleResult::allowed(1));
+
+        $factory = $this->createMock(ThrottleFactoryInterface::class);
+        $factory->method('create')->willReturn($throttler);
+
+        $user = new AuthenticatedUser('99', 'partner@example.com', ['partner'], UserType::PARTNER);
+        $securityContext = new StubSecurityContext($user);
+
+        $decorator = $this->createDecorator($inner, $throttleConfig, $securityContext, $factory);
+        $decorator->dispatch(new TestCommand('test'));
+    }
+}

--- a/backend/tests/Unit/SharedKernel/Infrastructure/CqrsMessageBus/Decorators/QueryThrottleDecoratorTest.php
+++ b/backend/tests/Unit/SharedKernel/Infrastructure/CqrsMessageBus/Decorators/QueryThrottleDecoratorTest.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\SharedKernel\Infrastructure\CqrsMessageBus\Decorators;
+
+use PHPUnit\Framework\TestCase;
+use SharedKernel\Application\CqrsMessageBus\Queries\QueryBusInterface;
+use SharedKernel\Application\Throttle\ThrottleConfigResolverInterface;
+use SharedKernel\Domain\EventSystem\AsyncEventProcessorInterface;
+use SharedKernel\Domain\Logger\LoggerInterface;
+use SharedKernel\Domain\Throttle\Exceptions\ThrottleDriverException;
+use SharedKernel\Domain\Security\AuthenticatedUser;
+use SharedKernel\Domain\Security\UserType;
+use SharedKernel\Domain\Throttle\Exceptions\ThrottleException;
+use SharedKernel\Domain\Throttle\ThrottleConfig;
+use SharedKernel\Domain\Throttle\ThrottleFactoryInterface;
+use SharedKernel\Domain\Throttle\ThrottleResolveResult;
+use SharedKernel\Domain\Throttle\ThrottleInterface;
+use SharedKernel\Domain\Throttle\ThrottleResult;
+use SharedKernel\Infrastructure\CqrsMessageBus\Decorators\QueryThrottleDecorator;
+use Tests\Fixtures\SharedKernel\CqrsMessageBus\TestQuery;
+use Tests\Fixtures\SharedKernel\CqrsMessageBus\TestQueryResponse;
+use Tests\Fixtures\SharedKernel\Http\StubRequestContext;
+use Tests\Fixtures\SharedKernel\Security\StubSecurityContext;
+
+class QueryThrottleDecoratorTest extends TestCase
+{
+    private function createConfig(): ThrottleConfig
+    {
+        return ThrottleConfig::fromArray([
+            'warning_limit' => 20,
+            'block_limit' => 30,
+            'window' => 60,
+        ]);
+    }
+
+    private function createDecorator(
+        QueryBusInterface $inner,
+        ThrottleConfigResolverInterface $throttleConfig,
+        StubSecurityContext $securityContext,
+        ?ThrottleFactoryInterface $throttleFactory = null,
+        ?AsyncEventProcessorInterface $asyncEventProcessor = null,
+        ?LoggerInterface $logger = null,
+        ?StubRequestContext $requestContext = null
+    ): QueryThrottleDecorator {
+        return new QueryThrottleDecorator(
+            $inner,
+            $throttleFactory ?? $this->createMock(ThrottleFactoryInterface::class),
+            $throttleConfig,
+            $securityContext,
+            $requestContext ?? new StubRequestContext('192.168.1.1'),
+            $asyncEventProcessor ?? $this->createMock(AsyncEventProcessorInterface::class),
+            $logger ?? $this->createMock(LoggerInterface::class)
+        );
+    }
+
+    private function createInner(?TestQueryResponse $response = null): QueryBusInterface
+    {
+        $inner = $this->createMock(QueryBusInterface::class);
+        $inner->method('dispatch')->willReturn($response ?? new TestQueryResponse('result'));
+
+        return $inner;
+    }
+
+    public function testAuthenticatedUserAllowedReturnsResponse(): void
+    {
+        $expectedResponse = new TestQueryResponse('data');
+        $inner = $this->createMock(QueryBusInterface::class);
+        $inner->expects($this->once())->method('dispatch')->willReturn($expectedResponse);
+
+        $throttleConfig = $this->createMock(ThrottleConfigResolverInterface::class);
+        $throttleConfig->method('resolve')->willReturn(ThrottleResolveResult::forDefault($this->createConfig()));
+
+        $throttler = $this->createMock(ThrottleInterface::class);
+        $throttler->method('attempt')->willReturn(ThrottleResult::allowed(5));
+
+        $factory = $this->createMock(ThrottleFactoryInterface::class);
+        $factory->method('create')->willReturn($throttler);
+
+        $user = new AuthenticatedUser('42', 'user@example.com', ['user'], UserType::CUSTOMER);
+        $securityContext = new StubSecurityContext($user);
+
+        $decorator = $this->createDecorator($inner, $throttleConfig, $securityContext, $factory);
+        $result = $decorator->dispatch(new TestQuery('1'));
+
+        $this->assertSame($expectedResponse, $result);
+    }
+
+    public function testAuthenticatedUserBlockedThrowsException(): void
+    {
+        $inner = $this->createMock(QueryBusInterface::class);
+        $inner->expects($this->never())->method('dispatch');
+
+        $throttleConfig = $this->createMock(ThrottleConfigResolverInterface::class);
+        $throttleConfig->method('resolve')->willReturn(ThrottleResolveResult::forDefault($this->createConfig()));
+
+        $throttler = $this->createMock(ThrottleInterface::class);
+        $throttler->method('attempt')->willReturn(ThrottleResult::blocked(300));
+
+        $factory = $this->createMock(ThrottleFactoryInterface::class);
+        $factory->method('create')->willReturn($throttler);
+
+        $user = new AuthenticatedUser('42', 'user@example.com', ['user'], UserType::CUSTOMER);
+        $securityContext = new StubSecurityContext($user);
+
+        $decorator = $this->createDecorator($inner, $throttleConfig, $securityContext, $factory);
+
+        $this->expectException(ThrottleException::class);
+        $decorator->dispatch(new TestQuery('1'));
+    }
+
+    public function testAdminExemptReturnsResponse(): void
+    {
+        $inner = $this->createInner();
+
+        $throttleConfig = $this->createMock(ThrottleConfigResolverInterface::class);
+        $throttleConfig->method('resolve')->willReturn(null);
+
+        $factory = $this->createMock(ThrottleFactoryInterface::class);
+        $factory->expects($this->never())->method('create');
+
+        $user = new AuthenticatedUser('1', 'admin@example.com', ['admin'], UserType::ADMIN);
+        $securityContext = new StubSecurityContext($user);
+
+        $decorator = $this->createDecorator($inner, $throttleConfig, $securityContext, $factory);
+        $result = $decorator->dispatch(new TestQuery('1'));
+
+        $this->assertInstanceOf(TestQueryResponse::class, $result);
+    }
+
+    public function testAnonymousUserAllowedReturnsResponse(): void
+    {
+        $inner = $this->createInner();
+
+        $throttleConfig = $this->createMock(ThrottleConfigResolverInterface::class);
+        $throttleConfig->method('resolve')
+            ->with(TestQuery::class, 'query', null)
+            ->willReturn(ThrottleResolveResult::forDefault($this->createConfig()));
+
+        $throttler = $this->createMock(ThrottleInterface::class);
+        $throttler->method('attempt')
+            ->with('ip:10.0.0.1')
+            ->willReturn(ThrottleResult::allowed(3));
+
+        $factory = $this->createMock(ThrottleFactoryInterface::class);
+        $factory->method('create')->willReturn($throttler);
+
+        $securityContext = new StubSecurityContext(null);
+        $requestContext = new StubRequestContext('10.0.0.1');
+
+        $decorator = $this->createDecorator(
+            $inner,
+            $throttleConfig,
+            $securityContext,
+            $factory,
+            null,
+            null,
+            $requestContext
+        );
+        $result = $decorator->dispatch(new TestQuery('1'));
+
+        $this->assertInstanceOf(TestQueryResponse::class, $result);
+    }
+
+    public function testAnonymousUserBlockedThrowsException(): void
+    {
+        $inner = $this->createMock(QueryBusInterface::class);
+        $inner->expects($this->never())->method('dispatch');
+
+        $throttleConfig = $this->createMock(ThrottleConfigResolverInterface::class);
+        $throttleConfig->method('resolve')->willReturn(ThrottleResolveResult::forDefault($this->createConfig()));
+
+        $throttler = $this->createMock(ThrottleInterface::class);
+        $throttler->method('attempt')->willReturn(ThrottleResult::blocked(600));
+
+        $factory = $this->createMock(ThrottleFactoryInterface::class);
+        $factory->method('create')->willReturn($throttler);
+
+        $securityContext = new StubSecurityContext(null);
+
+        $decorator = $this->createDecorator($inner, $throttleConfig, $securityContext, $factory);
+
+        $this->expectException(ThrottleException::class);
+        $decorator->dispatch(new TestQuery('1'));
+    }
+
+    public function testRedisConnectionFailureAllowsThrough(): void
+    {
+        $inner = $this->createInner();
+
+        $throttleConfig = $this->createMock(ThrottleConfigResolverInterface::class);
+        $throttleConfig->method('resolve')->willReturn(ThrottleResolveResult::forDefault($this->createConfig()));
+
+        $throttler = $this->createMock(ThrottleInterface::class);
+        $throttler->method('attempt')->willThrowException(new ThrottleDriverException('Connection refused'));
+
+        $factory = $this->createMock(ThrottleFactoryInterface::class);
+        $factory->method('create')->willReturn($throttler);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('error');
+
+        $user = new AuthenticatedUser('42', 'user@example.com', ['user'], UserType::CUSTOMER);
+        $securityContext = new StubSecurityContext($user);
+
+        $decorator = $this->createDecorator(
+            $inner,
+            $throttleConfig,
+            $securityContext,
+            $factory,
+            null,
+            $logger
+        );
+        $result = $decorator->dispatch(new TestQuery('1'));
+
+        $this->assertInstanceOf(TestQueryResponse::class, $result);
+    }
+
+    public function testWarningThresholdFiresEventAndStillReturnsResponse(): void
+    {
+        $inner = $this->createInner();
+        $config = $this->createConfig();
+
+        $throttleConfig = $this->createMock(ThrottleConfigResolverInterface::class);
+        $throttleConfig->method('resolve')->willReturn(ThrottleResolveResult::forDefault($config));
+
+        $throttler = $this->createMock(ThrottleInterface::class);
+        $throttler->method('attempt')->willReturn(ThrottleResult::warning($config->getWarningLimit()));
+
+        $factory = $this->createMock(ThrottleFactoryInterface::class);
+        $factory->method('create')->willReturn($throttler);
+
+        $asyncProcessor = $this->createMock(AsyncEventProcessorInterface::class);
+        $asyncProcessor->expects($this->once())->method('store');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('warning');
+
+        $user = new AuthenticatedUser('42', 'user@example.com', ['user'], UserType::CUSTOMER);
+        $securityContext = new StubSecurityContext($user);
+
+        $decorator = $this->createDecorator(
+            $inner,
+            $throttleConfig,
+            $securityContext,
+            $factory,
+            $asyncProcessor,
+            $logger
+        );
+        $result = $decorator->dispatch(new TestQuery('1'));
+
+        $this->assertInstanceOf(TestQueryResponse::class, $result);
+    }
+}

--- a/backend/tests/Unit/SharedKernel/Infrastructure/Throttle/ThrottleConfigResolverTest.php
+++ b/backend/tests/Unit/SharedKernel/Infrastructure/Throttle/ThrottleConfigResolverTest.php
@@ -1,0 +1,355 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\SharedKernel\Infrastructure\Throttle;
+
+use PHPUnit\Framework\TestCase;
+use SharedKernel\Domain\Security\UserType;
+use SharedKernel\Infrastructure\Throttle\ThrottleConfigResolver;
+
+class ThrottleConfigResolverTest extends TestCase
+{
+    private function createConfig(array $overrides = []): array
+    {
+        return array_merge([
+            'defaults' => [
+                UserType::ADMIN => null,
+                UserType::PARTNER => [
+                    'warning_limit' => 100,
+                    'block_limit' => 200,
+                    'window' => 60,
+                    'penalties' => [300, 3600],
+                    'recovery_period' => 3600,
+                ],
+                UserType::CUSTOMER => [
+                    'warning_limit' => 30,
+                    'block_limit' => 50,
+                    'window' => 60,
+                    'penalties' => [300, 3600, 10800],
+                    'recovery_period' => 10800,
+                ],
+            ],
+            'commands' => [],
+            'queries' => [],
+            'excluded' => [],
+        ], $overrides);
+    }
+
+    public function testExcludedMessageReturnsNull(): void
+    {
+        $service = new ThrottleConfigResolver($this->createConfig([
+            'excluded' => ['App\\Query\\HealthCheckQuery'],
+        ]));
+
+        $result = $service->resolve('App\\Query\\HealthCheckQuery', 'query', UserType::CUSTOMER);
+
+        $this->assertNull($result);
+    }
+
+    public function testExcludedMessageReturnsNullForAnonymous(): void
+    {
+        $service = new ThrottleConfigResolver($this->createConfig([
+            'excluded' => ['App\\Command\\PingCommand'],
+        ]));
+
+        $result = $service->resolve('App\\Command\\PingCommand', 'command', null);
+
+        $this->assertNull($result);
+    }
+
+    public function testPerCommandOverrideForSpecificUserType(): void
+    {
+        $service = new ThrottleConfigResolver($this->createConfig([
+            'commands' => [
+                'App\\Command\\CreateOrder' => [
+                    UserType::PARTNER => [
+                        'warning_limit' => 500,
+                        'block_limit' => 800,
+                        'window' => 60,
+                    ],
+                ],
+            ],
+        ]));
+
+        $result = $service->resolve('App\\Command\\CreateOrder', 'command', UserType::PARTNER);
+
+        $this->assertNotNull($result);
+        $this->assertSame(500, $result->getConfig()->getWarningLimit());
+        $this->assertSame(800, $result->getConfig()->getBlockLimit());
+        $this->assertSame('CreateOrder', $result->getScope());
+    }
+
+    public function testPerCommandSplitConfigAuthenticatedKey(): void
+    {
+        $service = new ThrottleConfigResolver($this->createConfig([
+            'commands' => [
+                'App\\Command\\ContactForm' => [
+                    'authenticated' => [
+                        'warning_limit' => 20,
+                        'block_limit' => 30,
+                        'window' => 3600,
+                    ],
+                    UserType::ANONYMOUS => [
+                        'warning_limit' => 3,
+                        'block_limit' => 5,
+                        'window' => 3600,
+                    ],
+                ],
+            ],
+        ]));
+
+        // Customer resolves via 'authenticated' catch-all
+        $result = $service->resolve('App\\Command\\ContactForm', 'command', UserType::CUSTOMER);
+
+        $this->assertNotNull($result);
+        $this->assertSame(20, $result->getConfig()->getWarningLimit());
+        $this->assertSame(30, $result->getConfig()->getBlockLimit());
+    }
+
+    public function testPerCommandSplitConfigAuthenticatedKeyForPartner(): void
+    {
+        $service = new ThrottleConfigResolver($this->createConfig([
+            'commands' => [
+                'App\\Command\\ContactForm' => [
+                    'authenticated' => [
+                        'warning_limit' => 20,
+                        'block_limit' => 30,
+                        'window' => 3600,
+                    ],
+                    UserType::ANONYMOUS => [
+                        'warning_limit' => 3,
+                        'block_limit' => 5,
+                        'window' => 3600,
+                    ],
+                ],
+            ],
+        ]));
+
+        // Partner also resolves via 'authenticated' catch-all
+        $result = $service->resolve('App\\Command\\ContactForm', 'command', UserType::PARTNER);
+
+        $this->assertNotNull($result);
+        $this->assertSame(20, $result->getConfig()->getWarningLimit());
+    }
+
+    public function testPerCommandSplitConfigAnonymousKey(): void
+    {
+        $service = new ThrottleConfigResolver($this->createConfig([
+            'commands' => [
+                'App\\Command\\ContactForm' => [
+                    'authenticated' => [
+                        'warning_limit' => 20,
+                        'block_limit' => 30,
+                        'window' => 3600,
+                    ],
+                    UserType::ANONYMOUS => [
+                        'warning_limit' => 3,
+                        'block_limit' => 5,
+                        'window' => 3600,
+                    ],
+                ],
+            ],
+        ]));
+
+        $result = $service->resolve('App\\Command\\ContactForm', 'command', null);
+
+        $this->assertNotNull($result);
+        $this->assertSame(3, $result->getConfig()->getWarningLimit());
+        $this->assertSame(5, $result->getConfig()->getBlockLimit());
+    }
+
+    public function testExactUserTypeOverridesTakePriorityOverAuthenticatedCatchAll(): void
+    {
+        $service = new ThrottleConfigResolver($this->createConfig([
+            'commands' => [
+                'App\\Command\\BulkImport' => [
+                    UserType::PARTNER => [
+                        'warning_limit' => 500,
+                        'block_limit' => 1000,
+                        'window' => 60,
+                    ],
+                    'authenticated' => [
+                        'warning_limit' => 20,
+                        'block_limit' => 30,
+                        'window' => 60,
+                    ],
+                ],
+            ],
+        ]));
+
+        // Partner gets its specific config, not the 'authenticated' catch-all
+        $result = $service->resolve('App\\Command\\BulkImport', 'command', UserType::PARTNER);
+
+        $this->assertNotNull($result);
+        $this->assertSame(500, $result->getConfig()->getWarningLimit());
+
+        // Customer falls through to 'authenticated' catch-all
+        $result = $service->resolve('App\\Command\\BulkImport', 'command', UserType::CUSTOMER);
+
+        $this->assertNotNull($result);
+        $this->assertSame(20, $result->getConfig()->getWarningLimit());
+    }
+
+    public function testPerCommandFlatConfigAppliesToAllUserTypes(): void
+    {
+        $service = new ThrottleConfigResolver($this->createConfig([
+            'commands' => [
+                'App\\Command\\CreateOrder' => [
+                    'warning_limit' => 10,
+                    'block_limit' => 15,
+                    'window' => 60,
+                ],
+            ],
+        ]));
+
+        $customerResult = $service->resolve('App\\Command\\CreateOrder', 'command', UserType::CUSTOMER);
+        $anonResult = $service->resolve('App\\Command\\CreateOrder', 'command', null);
+
+        $this->assertNotNull($customerResult);
+        $this->assertNotNull($anonResult);
+        $this->assertSame(10, $customerResult->getConfig()->getWarningLimit());
+        $this->assertSame('CreateOrder', $customerResult->getScope());
+        $this->assertSame(10, $anonResult->getConfig()->getWarningLimit());
+        $this->assertSame('CreateOrder', $anonResult->getScope());
+    }
+
+    public function testFallsBackToDefaultsForUserType(): void
+    {
+        $service = new ThrottleConfigResolver($this->createConfig());
+
+        $result = $service->resolve('App\\Command\\SomeCommand', 'command', UserType::CUSTOMER);
+
+        $this->assertNotNull($result);
+        $this->assertSame(30, $result->getConfig()->getWarningLimit());
+        $this->assertSame(50, $result->getConfig()->getBlockLimit());
+        $this->assertSame('__default__', $result->getScope());
+    }
+
+    public function testFallsBackToDefaultsForPartner(): void
+    {
+        $service = new ThrottleConfigResolver($this->createConfig());
+
+        $result = $service->resolve('App\\Command\\SomeCommand', 'command', UserType::PARTNER);
+
+        $this->assertNotNull($result);
+        $this->assertSame(100, $result->getConfig()->getWarningLimit());
+        $this->assertSame(200, $result->getConfig()->getBlockLimit());
+        $this->assertSame('__default__', $result->getScope());
+    }
+
+    public function testAdminDefaultNullReturnsNull(): void
+    {
+        $service = new ThrottleConfigResolver($this->createConfig());
+
+        $result = $service->resolve('App\\Command\\SomeCommand', 'command', UserType::ADMIN);
+
+        $this->assertNull($result);
+    }
+
+    public function testAnonymousWithNoDefaultAndNoPerCommandConfigReturnsNull(): void
+    {
+        $service = new ThrottleConfigResolver($this->createConfig());
+
+        $result = $service->resolve('App\\Command\\SomeCommand', 'command', null);
+
+        // No anonymous default — broad anonymous throttling handled at HTTP layer
+        $this->assertNull($result);
+    }
+
+    public function testAnonymousWithPerCommandOverrideReturnsConfig(): void
+    {
+        $service = new ThrottleConfigResolver($this->createConfig([
+            'commands' => [
+                'App\\Command\\ContactForm' => [
+                    UserType::ANONYMOUS => [
+                        'warning_limit' => 3,
+                        'block_limit' => 5,
+                        'window' => 3600,
+                    ],
+                ],
+            ],
+        ]));
+
+        $result = $service->resolve('App\\Command\\ContactForm', 'command', null);
+
+        $this->assertNotNull($result);
+        $this->assertSame(3, $result->getConfig()->getWarningLimit());
+        $this->assertSame(5, $result->getConfig()->getBlockLimit());
+        $this->assertSame('ContactForm', $result->getScope());
+    }
+
+    public function testUnknownUserTypeWithNoDefaultReturnsNull(): void
+    {
+        $service = new ThrottleConfigResolver($this->createConfig([
+            'defaults' => [
+                UserType::CUSTOMER => [
+                    'warning_limit' => 30,
+                    'block_limit' => 50,
+                    'window' => 60,
+                ],
+            ],
+        ]));
+
+        $result = $service->resolve('App\\Command\\SomeCommand', 'command', 'unknown_type');
+
+        $this->assertNull($result);
+    }
+
+    public function testQueryResolution(): void
+    {
+        $service = new ThrottleConfigResolver($this->createConfig([
+            'queries' => [
+                'App\\Query\\SearchProducts' => [
+                    'warning_limit' => 80,
+                    'block_limit' => 120,
+                    'window' => 60,
+                ],
+            ],
+        ]));
+
+        $result = $service->resolve('App\\Query\\SearchProducts', 'query', UserType::CUSTOMER);
+
+        $this->assertNotNull($result);
+        $this->assertSame(80, $result->getConfig()->getWarningLimit());
+    }
+
+    public function testQueryFallsBackToDefaults(): void
+    {
+        $service = new ThrottleConfigResolver($this->createConfig());
+
+        $result = $service->resolve('App\\Query\\SomeQuery', 'query', UserType::CUSTOMER);
+
+        $this->assertNotNull($result);
+        $this->assertSame(30, $result->getConfig()->getWarningLimit());
+    }
+
+    public function testEmptyConfigReturnsNull(): void
+    {
+        $service = new ThrottleConfigResolver([]);
+
+        $result = $service->resolve('App\\Command\\SomeCommand', 'command', UserType::CUSTOMER);
+
+        $this->assertNull($result);
+    }
+
+    public function testCommandConfigDoesNotAffectQueryResolution(): void
+    {
+        $service = new ThrottleConfigResolver($this->createConfig([
+            'commands' => [
+                'App\\Shared\\SomeName' => [
+                    'warning_limit' => 999,
+                    'block_limit' => 1000,
+                    'window' => 60,
+                ],
+            ],
+        ]));
+
+        // Same class name in 'query' section should not find the command config
+        $result = $service->resolve('App\\Shared\\SomeName', 'query', UserType::CUSTOMER);
+
+        $this->assertNotNull($result);
+        // Falls through to customer default, not the command config
+        $this->assertSame(30, $result->getConfig()->getWarningLimit());
+    }
+}

--- a/dev-tools/cleanup.sh
+++ b/dev-tools/cleanup.sh
@@ -13,6 +13,8 @@ HOSTS_FILE="/etc/hosts"
 # List of domains to remove
 DOMAINS=(
   "php-ddd.test"
+  "admin.php-ddd.test"
+  "partner.php-ddd.test"
   "images.php-ddd.test"
   "mail.php-ddd.test"
   "dashboard.php-ddd.test"

--- a/dev-tools/dashboard/config.yml
+++ b/dev-tools/dashboard/config.yml
@@ -63,6 +63,22 @@ services:
         url: "https://php-ddd.test"
         target: "_blank"
 
+      - name: "Admin Panel"
+        icon: "fas fa-shield-alt"
+        subtitle: "Admin Module (IP Restricted)"
+        tag: "admin"
+        keywords: "admin panel management"
+        url: "https://admin.php-ddd.test"
+        target: "_blank"
+
+      - name: "Partner Portal"
+        icon: "fas fa-handshake"
+        subtitle: "Partner Module"
+        tag: "partner"
+        keywords: "partner portal"
+        url: "https://partner.php-ddd.test"
+        target: "_blank"
+
       - name: "Images CDN"
         icon: "fas fa-images"
         subtitle: "Image Assets Only"

--- a/dev-tools/dns-mapping.sh
+++ b/dev-tools/dns-mapping.sh
@@ -3,6 +3,8 @@
 # Define domains to map
 DOMAINS=(
   "php-ddd.test"
+  "admin.php-ddd.test"
+  "partner.php-ddd.test"
   "images.php-ddd.test"
   "mail.php-ddd.test"
   "dashboard.php-ddd.test"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,10 +92,26 @@ services:
       - "traefik.http.routers.app.entrypoints=websecure"
       - "traefik.http.routers.app.tls=true"
       - "traefik.http.services.app.loadbalancer.server.port=80"
+      # Admin subdomain
+      - "traefik.http.routers.app-admin.rule=Host(`admin.php-ddd.test`)"
+      - "traefik.http.routers.app-admin.entrypoints=websecure"
+      - "traefik.http.routers.app-admin.tls=true"
+      - "traefik.http.routers.app-admin.service=app"
+      # Partner subdomain
+      - "traefik.http.routers.app-partner.rule=Host(`partner.php-ddd.test`)"
+      - "traefik.http.routers.app-partner.entrypoints=websecure"
+      - "traefik.http.routers.app-partner.tls=true"
+      - "traefik.http.routers.app-partner.service=app"
       # HTTP to HTTPS redirect
       - "traefik.http.routers.app-http.rule=Host(`php-ddd.test`)"
       - "traefik.http.routers.app-http.entrypoints=web"
       - "traefik.http.routers.app-http.middlewares=redirect-to-https"
+      - "traefik.http.routers.app-admin-http.rule=Host(`admin.php-ddd.test`)"
+      - "traefik.http.routers.app-admin-http.entrypoints=web"
+      - "traefik.http.routers.app-admin-http.middlewares=redirect-to-https"
+      - "traefik.http.routers.app-partner-http.rule=Host(`partner.php-ddd.test`)"
+      - "traefik.http.routers.app-partner-http.entrypoints=web"
+      - "traefik.http.routers.app-partner-http.middlewares=redirect-to-https"
       - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
   fuelphp:
     build:

--- a/fuelphp/fuel/app/classes/httptoomanyrequestsexception.php
+++ b/fuelphp/fuel/app/classes/httptoomanyrequestsexception.php
@@ -1,0 +1,31 @@
+<?php
+
+use Fuel\Core\HttpException;
+use Fuel\Core\Response;
+
+class HttpTooManyRequestsException extends HttpException
+{
+    private int $retryAfter;
+
+    public function __construct(int $retryAfter = 0, string $message = 'Too many requests. Please try again later.')
+    {
+        $this->retryAfter = $retryAfter;
+        parent::__construct($message);
+    }
+
+    public function response(): Response
+    {
+        $response = new Response('Too many requests. Please try again later.', 429);
+
+        if ($this->retryAfter > 0) {
+            $response->set_header('Retry-After', (string) $this->retryAfter);
+        }
+
+        return $response;
+    }
+
+    public function getRetryAfter(): int
+    {
+        return $this->retryAfter;
+    }
+}

--- a/fuelphp/fuel/app/config/di.php
+++ b/fuelphp/fuel/app/config/di.php
@@ -4,10 +4,14 @@ use DI\ContainerBuilder;
 use Fuel\Core\Fuel;
 use Infrastructure\EventSystem\FuelPhpOutboxRepository;
 use Infrastructure\EventSystem\FuelPhpScheduledEventRepository;
+use Infrastructure\Http\FuelPhpRequestContext;
+use Infrastructure\Security\FuelPhpSecurityContext;
 use Psr\Container\ContainerInterface;
 use SharedKernel\Application\CqrsMessageBus\Commands\CommandBusInterface;
 use SharedKernel\Application\CqrsMessageBus\Queries\QueryBusInterface;
 use SharedKernel\Application\CqrsMessageBus\TransactionManagerInterface;
+use SharedKernel\Application\Http\RequestContextInterface;
+use SharedKernel\Application\Throttle\ThrottleConfigResolverInterface;
 use SharedKernel\Domain\Cache\CacheInterface;
 use SharedKernel\Domain\Environment;
 use SharedKernel\Domain\EventSystem\AsyncEventProcessorInterface;
@@ -18,23 +22,30 @@ use SharedKernel\Domain\EventSystem\OutboxEventProcessorInterface;
 use SharedKernel\Domain\EventSystem\ScheduledEventProcessorInterface;
 use SharedKernel\Domain\Logger\LoggerInterface;
 use SharedKernel\Domain\Redis\RedisClientInterface;
+use SharedKernel\Domain\Security\SecurityContextInterface;
 use SharedKernel\Domain\Storage\StorageInterface;
+use SharedKernel\Domain\Throttle\ThrottleFactoryInterface;
 use SharedKernel\Infrastructure\Cache\CacheFactory;
-use SharedKernel\Infrastructure\EventSystem\SqsAsyncEventProcessorFactory;
+use SharedKernel\Infrastructure\CqrsMessageBus\CommandBusFactory;
+use SharedKernel\Infrastructure\CqrsMessageBus\Decorators\CommandLoggerDecorator;
+use SharedKernel\Infrastructure\CqrsMessageBus\Decorators\CommandThrottleDecorator;
+use SharedKernel\Infrastructure\CqrsMessageBus\Decorators\CommandTransactionDecorator;
+use SharedKernel\Infrastructure\CqrsMessageBus\Decorators\QueryLoggerDecorator;
+use SharedKernel\Infrastructure\CqrsMessageBus\Decorators\QueryThrottleDecorator;
+use SharedKernel\Infrastructure\CqrsMessageBus\QueryBusFactory;
 use SharedKernel\Infrastructure\EventSystem\DomainEventCollector;
 use SharedKernel\Infrastructure\EventSystem\EventFactoryFactory;
 use SharedKernel\Infrastructure\EventSystem\ListenerProviderFactory;
 use SharedKernel\Infrastructure\EventSystem\OutboxEventProcessor;
 use SharedKernel\Infrastructure\EventSystem\ScheduledEventProcessor;
-use SharedKernel\Infrastructure\CqrsMessageBus\CommandBusFactory;
-use SharedKernel\Infrastructure\CqrsMessageBus\Decorators\CommandLoggerDecorator;
-use SharedKernel\Infrastructure\CqrsMessageBus\Decorators\CommandTransactionDecorator;
-use SharedKernel\Infrastructure\CqrsMessageBus\Decorators\QueryLoggerDecorator;
-use SharedKernel\Infrastructure\CqrsMessageBus\QueryBusFactory;
+use SharedKernel\Infrastructure\EventSystem\SqsAsyncEventProcessorFactory;
 use SharedKernel\Infrastructure\Logger\LoggerFactory;
 use SharedKernel\Infrastructure\Redis\RedisClientFactory;
 use SharedKernel\Infrastructure\Storage\CdnUrlResolver;
 use SharedKernel\Infrastructure\Storage\StorageFactory;
+use SharedKernel\Infrastructure\Throttle\ThrottleConfigDefaults;
+use SharedKernel\Infrastructure\Throttle\ThrottleConfigResolver;
+use SharedKernel\Infrastructure\Throttle\ThrottleDriverFactory;
 
 $containerBuilder = new ContainerBuilder();
 $repositories = require APPPATH . 'config/repositories.php';
@@ -45,19 +56,30 @@ if (Fuel::$env !== Fuel::DEVELOPMENT) {
 }
 
 $containerBuilder->addDefinitions(array_merge([
-    Environment::class => DI\create(Environment::class)->constructor(Fuel::$env, getenv('TEST_ENV_ID') ?: null),
+    Environment::class => DI\autowire(Environment::class)->constructor(Fuel::$env, getenv('TEST_ENV_ID') ?: null),
     LoggerInterface::class => DI\factory(LoggerFactory::class),
     RedisClientInterface::class => DI\factory(RedisClientFactory::class),
     CacheInterface::class => DI\factory(CacheFactory::class),
-    CdnUrlResolver::class => DI\create(CdnUrlResolver::class)->constructor([
+    CdnUrlResolver::class => DI\autowire(CdnUrlResolver::class)->constructor([
         'public/images/' => getenv('CDN_IMAGES_URL') ?: '',
     ]),
     StorageFactory::class => DI\autowire(StorageFactory::class),
-    StorageInterface::class => DI\factory(function(ContainerInterface $c) {
+    StorageInterface::class => DI\factory(function (ContainerInterface $c) {
         return $c->get(StorageFactory::class)->create();
     }),
 
+    // Security & Request Context
+    SecurityContextInterface::class => DI\autowire(FuelPhpSecurityContext::class),
+    RequestContextInterface::class => DI\autowire(FuelPhpRequestContext::class),
+
+    // Throttle
+    ThrottleFactoryInterface::class => DI\factory(ThrottleDriverFactory::class),
+    ThrottleConfigResolverInterface::class => DI\factory(function () {
+        return new ThrottleConfigResolver(ThrottleConfigDefaults::load());
+    }),
+
     // CQRS Message Bus
+    // Decorator chain (outermost → innermost): Throttle → Logger → Transaction → Handler
     CommandBusInterface::class => DI\factory(function (ContainerInterface $c) {
         $bus = (new CommandBusFactory($c, [
             // Add bounded-context registries here:
@@ -70,7 +92,16 @@ $containerBuilder->addDefinitions(array_merge([
             $c->get(TransactionManagerInterface::class),
             $c->get(OutboxEventProcessorInterface::class)
         );
-        return new CommandLoggerDecorator($bus, $c->get(LoggerInterface::class));
+        $bus = new CommandLoggerDecorator($bus, $c->get(LoggerInterface::class));
+        return new CommandThrottleDecorator(
+            $bus,
+            $c->get(ThrottleFactoryInterface::class),
+            $c->get(ThrottleConfigResolverInterface::class),
+            $c->get(SecurityContextInterface::class),
+            $c->get(RequestContextInterface::class),
+            $c->get(AsyncEventProcessorInterface::class),
+            $c->get(LoggerInterface::class)
+        );
     }),
     QueryBusInterface::class => DI\factory(function (ContainerInterface $c) {
         $bus = (new QueryBusFactory($c, [
@@ -78,30 +109,39 @@ $containerBuilder->addDefinitions(array_merge([
             // new CrmQueryHandlerRegistry(),
             // new MarketingQueryHandlerRegistry(),
         ]))();
-        return new QueryLoggerDecorator($bus, $c->get(LoggerInterface::class));
+        $bus = new QueryLoggerDecorator($bus, $c->get(LoggerInterface::class));
+        return new QueryThrottleDecorator(
+            $bus,
+            $c->get(ThrottleFactoryInterface::class),
+            $c->get(ThrottleConfigResolverInterface::class),
+            $c->get(SecurityContextInterface::class),
+            $c->get(RequestContextInterface::class),
+            $c->get(AsyncEventProcessorInterface::class),
+            $c->get(LoggerInterface::class)
+        );
     }),
 
     // Event System
     EventFactoryInterface::class => DI\factory(EventFactoryFactory::class),
     ListenerProviderInterface::class => DI\factory(ListenerProviderFactory::class),
-    DomainEventCollectorInterface::class => DI\create(DomainEventCollector::class),
+    DomainEventCollectorInterface::class => DI\autowire(DomainEventCollector::class),
 
     // Event Repositories (FuelPHP-specific)
     FuelPhpOutboxRepository::class => DI\autowire(FuelPhpOutboxRepository::class),
     FuelPhpScheduledEventRepository::class => DI\autowire(FuelPhpScheduledEventRepository::class),
 
     // Event Processors (wired explicitly to their repositories)
-    OutboxEventProcessorInterface::class => DI\create(OutboxEventProcessor::class)->constructor(
+    OutboxEventProcessorInterface::class => DI\autowire(OutboxEventProcessor::class)->constructor(
         DI\get(FuelPhpOutboxRepository::class),
         DI\get(ListenerProviderInterface::class),
         DI\get(LoggerInterface::class)
     ),
-    ScheduledEventProcessorInterface::class => DI\create(ScheduledEventProcessor::class)->constructor(
+    ScheduledEventProcessorInterface::class => DI\autowire(ScheduledEventProcessor::class)->constructor(
         DI\get(FuelPhpScheduledEventRepository::class),
         DI\get(ListenerProviderInterface::class),
         DI\get(LoggerInterface::class)
     ),
-    SqsAsyncEventProcessorFactory::class => DI\create(SqsAsyncEventProcessorFactory::class)->constructor(
+    SqsAsyncEventProcessorFactory::class => DI\autowire(SqsAsyncEventProcessorFactory::class)->constructor(
         DI\get(Environment::class),
         DI\get(EventFactoryInterface::class),
         DI\get(ListenerProviderInterface::class),

--- a/fuelphp/fuel/app/config/routes.php
+++ b/fuelphp/fuel/app/config/routes.php
@@ -31,6 +31,9 @@ return array(
 	 */
 
 	'_404_' => 'welcome/404',
+	'_429_' => function () {
+		return Response::forge('Too many requests. Please try again later.', 429);
+	},
 
 	/**
 	 * -------------------------------------------------------------------------

--- a/fuelphp/fuel/app/config/subdomain.php
+++ b/fuelphp/fuel/app/config/subdomain.php
@@ -4,11 +4,15 @@ $host = $_SERVER['HTTP_X_FORWARDED_HOST'] ?? $_SERVER['HTTP_HOST'] ?? '';
 $uri = $_SERVER['REQUEST_URI'] ?? '/';
 
 // Restrict access to the modules directory directly
-if (preg_match('#^admin(/|$)#', ltrim($uri, '/'))) {
+if (preg_match('#^(admin|partner)(/|$)#', ltrim($uri, '/'))) {
     $_SERVER['REQUEST_URI'] = '/_404_';
 }
 
 // Route requests to the modules directory
 if (preg_match('/^admin\./', $host)) {
     $_SERVER['REQUEST_URI'] = '/admin' . $uri;
+}
+
+if (preg_match('/^partner\./', $host)) {
+    $_SERVER['REQUEST_URI'] = '/partner' . $uri;
 }

--- a/fuelphp/fuel/app/modules/partner/classes/controller/abstract.php
+++ b/fuelphp/fuel/app/modules/partner/classes/controller/abstract.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Partner;
+
+use Fuel\Core\Controller;
+use HttpTooManyRequestsException;
+use Infrastructure\Throttle\HttpThrottleTrait;
+
+abstract class Controller_Abstract extends Controller
+{
+    use HttpThrottleTrait;
+
+    /**
+     * @throws HttpTooManyRequestsException
+     */
+    public function before()
+    {
+        $this->throttleBeforeRequest();
+
+        parent::before();
+    }
+}

--- a/fuelphp/fuel/app/modules/partner/classes/controller/welcome.php
+++ b/fuelphp/fuel/app/modules/partner/classes/controller/welcome.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Partner;
+
+use Fuel\Core\Response;
+use Fuel\Core\View;
+
+class Controller_Welcome extends Controller_Abstract
+{
+    public function action_index()
+    {
+        return Response::forge(View::forge('welcome/index'));
+    }
+}

--- a/fuelphp/fuel/app/modules/partner/config/routes.php
+++ b/fuelphp/fuel/app/modules/partner/config/routes.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'partner' => 'partner/welcome/index',
+];

--- a/fuelphp/fuel/app/modules/partner/views/welcome/index.php
+++ b/fuelphp/fuel/app/modules/partner/views/welcome/index.php
@@ -1,0 +1,1 @@
+<h1>Partner Portal</h1>

--- a/fuelphp/fuel/packages/infrastructure/classes/Http/FuelPhpRequestContext.php
+++ b/fuelphp/fuel/packages/infrastructure/classes/Http/FuelPhpRequestContext.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Infrastructure\Http;
+
+use Fuel\Core\Input;
+use SharedKernel\Application\Http\RequestContextInterface;
+
+final class FuelPhpRequestContext implements RequestContextInterface
+{
+    public function getClientIp(): string
+    {
+        return Input::real_ip();
+    }
+}

--- a/fuelphp/fuel/packages/infrastructure/classes/Security/FuelPhpSecurityContext.php
+++ b/fuelphp/fuel/packages/infrastructure/classes/Security/FuelPhpSecurityContext.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Infrastructure\Security;
+
+use SharedKernel\Domain\Security\AuthenticatedUser;
+use SharedKernel\Domain\Security\SecurityContextInterface;
+
+final class FuelPhpSecurityContext implements SecurityContextInterface
+{
+    private ?AuthenticatedUser $user = null;
+
+    public function getCurrentUser(): ?AuthenticatedUser
+    {
+        return $this->user;
+    }
+
+    public function setCurrentUser(AuthenticatedUser $user): void
+    {
+        $this->user = $user;
+    }
+
+    public function hasAuthenticatedUser(): bool
+    {
+        return $this->user !== null;
+    }
+
+    public function clearUser(): void
+    {
+        $this->user = null;
+    }
+}

--- a/fuelphp/fuel/packages/infrastructure/classes/Throttle/HttpThrottleTrait.php
+++ b/fuelphp/fuel/packages/infrastructure/classes/Throttle/HttpThrottleTrait.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Infrastructure\Throttle;
+
+use Container;
+use HttpTooManyRequestsException;
+use SharedKernel\Application\Http\RequestContextInterface;
+use SharedKernel\Domain\Logger\LoggerInterface;
+use SharedKernel\Domain\Security\SecurityContextInterface;
+use SharedKernel\Domain\Throttle\Exceptions\ThrottleDriverException;
+use SharedKernel\Domain\Throttle\ThrottleConfig;
+use SharedKernel\Domain\Throttle\ThrottleFactoryInterface;
+
+trait HttpThrottleTrait
+{
+    protected function throttleBeforeRequest(): void
+    {
+        /** @var SecurityContextInterface $securityContext */
+        $securityContext = Container::resolve(SecurityContextInterface::class);
+
+        if ($securityContext->hasAuthenticatedUser()) {
+            return;
+        }
+
+        try {
+            /** @var RequestContextInterface $requestContext */
+            $requestContext = Container::resolve(RequestContextInterface::class);
+            $clientIp = $requestContext->getClientIp();
+
+            $config = ThrottleConfig::fromArray([
+                'warning_limit' => 100,
+                'block_limit' => 200,
+                'window' => 60,
+                'penalties' => [300, 3600, 10800],
+                'recovery_period' => 10800,
+            ]);
+
+            /** @var ThrottleFactoryInterface $throttleFactory */
+            $throttleFactory = Container::resolve(ThrottleFactoryInterface::class);
+            $throttler = $throttleFactory->create($config, '__default__');
+
+            $identifier = 'ip:' . $clientIp;
+            $result = $throttler->attempt($identifier);
+
+            /** @var LoggerInterface $logger */
+            $logger = Container::resolve(LoggerInterface::class);
+
+            if ($result->isWarningTriggered() && $result->getCurrentAttempts() === $config->getWarningLimit()) {
+                $logger->warning('[HTTP_THROTTLE] Warning threshold reached', [
+                    'identifier' => $identifier,
+                    'request_count' => $result->getCurrentAttempts(),
+                ]);
+            }
+
+            if (!$result->isAllowed()) {
+                if ($result->getCurrentAttempts() === $config->getBlockLimit()) {
+                    $logger->warning('[HTTP_THROTTLE] Request blocked', [
+                        'identifier' => $identifier,
+                        'retry_after' => $result->getRetryAfter(),
+                    ]);
+                }
+                throw new HttpTooManyRequestsException($result->getRetryAfter());
+            }
+        } catch (ThrottleDriverException $e) {
+            /** @var LoggerInterface $logger */
+            $logger = Container::resolve(LoggerInterface::class);
+            $logger->error('[HTTP_THROTTLE] Driver connection failed - allowing request');
+        }
+    }
+}

--- a/fuelphp/public/index.php
+++ b/fuelphp/public/index.php
@@ -186,6 +186,10 @@ catch (HttpNotFoundException $e)
 {
 	$response = $routerequest('_404_', $e);
 }
+catch (HttpTooManyRequestsException $e)
+{
+	$response = $routerequest('_429_', $e);
+}
 catch (HttpServerErrorException $e)
 {
 	$response = $routerequest('_500_', $e);


### PR DESCRIPTION
implements config-driven rate limiting for commands, queries, and HTTP requests. see ADR-007 for architecture.

scope:
- `UserType` + `SecurityContextInterface` for identity resolution
- `RequestContextInterface` for client IP
- `expire()` added to `RedisClientInterface`
- throttle domain (config, events, exceptions, result types) + redis/null drivers
- `CommandThrottleDecorator` + `QueryThrottleDecorator` wired into CQRS bus
- FuelPHP `FuelPhpRequestContext` + `FuelPhpSecurityContext` implementations
- `HttpThrottleTrait` + `HttpTooManyRequestsException` for controller-level throttling
- admin/partner subdomain routing, new `partner` module

## Test plan
- [x] `make test-unit` passes
- [x] verify throttle events fire on rate-limit block/warning
- [x] verify 429 response from throttled controller