### PR TITLE
feat: SharedKernel security module (RBAC for CQRS) with audience-based authorization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ install:
 build:
 	docker compose build
 composer-autoload:
+	docker compose run --rm fuelphp composer -d backend dump-autoload
 	docker compose run --rm fuelphp composer -d fuelphp dump-autoload
 	docker compose run --rm laravel composer -d laravel dump-autoload
 up:

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -1,10 +1,11 @@
 {
   "name": "app/backend",
-  "description": "Domain layer with bounded contexts",
+  "description": "Domain layer with bounded contexts and audience modules",
   "type": "library",
   "license": "proprietary",
   "autoload": {
     "psr-4": {
+      "Audience\\": "src/Audience/",
       "Crm\\": "src/Crm/",
       "Marketing\\": "src/Marketing/",
       "SharedKernel\\": "src/SharedKernel/"

--- a/backend/docs/adr/007-rate-limiting-architecture.md
+++ b/backend/docs/adr/007-rate-limiting-architecture.md
@@ -5,12 +5,12 @@
 
 ## Context
 
-The system needs rate limiting at two levels: HTTP-level flood protection for anonymous traffic, and CQRS-level throttling for authenticated users and specific public endpoints. The CQRS throttle must support different limits per user type (admin, partner, customer, system worker), per-command/query overrides, progressive penalties for repeat offenders, and fail-open behavior when the storage backend is unavailable. The implementation must be framework-agnostic (PHP 7.4 compatible in `backend/src/`) for the CQRS layer, integrate with the existing CQRS decorator chain (ADR-006), and support the ongoing FuelPHP-to-Laravel migration.
+The system needs rate limiting at two levels: HTTP-level flood protection for anonymous traffic, and CQRS-level throttling for authenticated users and specific public endpoints. The CQRS throttle must support different limits per user type (admin, partner, customer), per-command/query overrides, progressive penalties for repeat offenders, and fail-open behavior when the storage backend is unavailable. The implementation must be framework-agnostic (PHP 7.4 compatible in `backend/src/`) for the CQRS layer, integrate with the existing CQRS decorator chain (ADR-006), and support the ongoing FuelPHP-to-Laravel migration.
 
 Key requirements:
 - HTTP layer: broad IP-based throttle for anonymous users, framework-specific
 - CQRS layer: rate limit authenticated users by user type + ID, with per-command overrides for both authenticated and anonymous
-- Different default limits per user type — admins and system workers exempt
+- Different default limits per user type — admins exempt
 - Progressive penalties that escalate block duration on repeated violations
 - Fail-open on storage driver failure — never block legitimate traffic due to infrastructure issues
 - No coupling between commands/queries and throttle configuration
@@ -71,16 +71,16 @@ Identity resolution was initially on the command, but this was moved to the deco
 
 ### User Types, Not Roles
 
-Throttle limits are keyed by user type (`UserType::ADMIN`, `PARTNER`, `CUSTOMER`, `SYSTEM`, `ANONYMOUS`), not by role. User type represents which authentication provider/table the user comes from — it's a fixed identity characteristic, not a permission grant. One user has exactly one type. `AuthenticatedUser` was extended with a `$type` field (defaulting to `UserType::CUSTOMER` for backward compatibility) to carry this information through the security context.
+Throttle limits are keyed by user type (`UserType::ADMIN`, `PARTNER`, `CUSTOMER`, `ANONYMOUS`), not by role. User type represents which authentication provider/table the user comes from — it's a fixed identity characteristic, not a permission grant. One user has exactly one type. `AuthenticatedUser` was extended with a `$type` field (defaulting to `UserType::CUSTOMER` for backward compatibility) to carry this information through the security context.
 
 Roles were considered but rejected because:
 - A user with multiple roles (`['user', 'manager']`) would need conflict resolution — which role's limits apply?
 - Roles are about authorization (what you can do), not identity (who you are)
 - The admin panel, partner portal, and customer portal are separate authentication contexts with separate tables — user type naturally maps to this
 
-`UserType::SYSTEM` was added for background workers and batch operations. Workers set a system-level `AuthenticatedUser` in `SecurityContextInterface` at bootstrap. The config exempts `SYSTEM` with `null` defaults, so workers are never throttled. This avoids maintaining exclusion lists of worker commands and works with the shared DI container (no separate config for workers).
-
 `UserType::ANONYMOUS` is a config-only concept — it represents the absence of an authenticated user. It's included in `UserType` constants so the config key space is consistent and validatable.
+
+Background event workers (ADR-005) process events through their own dispatch path and never enter the CQRS bus, so they bypass the throttle decorator entirely. No worker-specific user type is required.
 
 ### Decorator Chain Order
 
@@ -174,7 +174,7 @@ The user type prefix in the identifier (`customer:42` vs `partner:42`) ensures u
 | `ThrottleConfigException` | Domain | Invalid configuration values |
 | `CqrsThrottleWarningEvent` | Domain | Async event: warning threshold crossed |
 | `CqrsThrottleBlockedEvent` | Domain | Async event: request blocked |
-| `UserType` | Domain | Constants: ADMIN, PARTNER, CUSTOMER, SYSTEM, ANONYMOUS |
+| `UserType` | Domain | Constants: ADMIN, PARTNER, CUSTOMER, ANONYMOUS |
 | `SecurityContextInterface` | Domain | Request-scoped user identity |
 | `ThrottleConfigResolverInterface` | Application | Contract: resolve config by command class and user type |
 | `RequestContextInterface` | Application | Client IP address |
@@ -203,6 +203,6 @@ The user type prefix in the identifier (`customer:42` vs `partner:42`) ensures u
 - Anonymous protection is split across two layers — requires coordinating HTTP and CQRS throttle configs
 - Config resolution has multiple fallback steps — debugging "which config was applied?" requires understanding the chain
 - `UserType::ANONYMOUS` is not a real user type but is included in constants for config key consistency
-- New commands get throttled by defaults automatically — no opt-in required, which could surprise developers adding internal commands (mitigation: use `excluded` list or `SYSTEM` user type for workers)
+- New commands get throttled by defaults automatically — no opt-in required, which could surprise developers adding internal commands (mitigation: use the `excluded` list)
 - `ThrottleConfigDefaults` is a static config class, not a file-based config — changing defaults requires a code deploy, not a config file change
 - HTTP layer throttle is framework-specific — each framework (FuelPHP, Laravel) needs its own implementation

--- a/backend/docs/adr/008-security-module.md
+++ b/backend/docs/adr/008-security-module.md
@@ -1,0 +1,197 @@
+# ADR-008: Security Module (RBAC for CQRS)
+
+**Status:** Accepted
+**Date:** 2026-04-25
+
+## Context
+
+The system needs authentication context and authorization for CQRS commands and queries across three audiences (admin panel, partner portal, customer-facing) that will eventually run on different drivers — FuelPHP Auth in the short term for all three, with admin migrating to AWS Cognito JWT and customer to Laravel Auth as the framework migration proceeds. The implementation must be framework-agnostic at the domain layer (PHP 7.4 compatible in `backend/src/`), integrate with the existing CQRS decorator chain (ADR-006) and rate-limiting layer (ADR-007), and support the ongoing FuelPHP-to-Laravel migration without coupling the domain to either framework.
+
+Key requirements:
+- Role-based access control on every command and query, with permissions decoupled from roles to prevent role explosion when adding cross-cutting access (e.g., "some managers also need invoice access")
+- Pluggable per-driver authentication that hides framework specifics behind a uniform `AuthenticatedUser` value object
+- Audience-based ownership of commands, queries, and roles — admin portal owns admin commands and roles; partner portal owns partner's; customer same. Bounded contexts (Crm, Marketing, Billing) own only the domain layer (aggregates, events) and are framework-agnostic libraries that audience commands operate on. No central registry forced on audience teams.
+- Fail-closed-by-default: a command without a security configuration entry must throw, not silently allow
+- Explicit support for public commands/queries (marketing context will have many) without weakening the fail-closed property
+- Coexistence with throttling, logging, and transaction decorators in the existing chain
+
+## Decision
+
+### Authorization is by Permission Only
+
+Commands and queries declare a **permission name** (a string) — never a list of allowed roles. Roles map to permission lists in a separate config section. A user is authorized for a command if any of their roles grants the required permission. The wildcard `*` grants every permission.
+
+This is the standard split that prevents role explosion. When "some managers also need invoice access" appears, the answer is to give those specific users an additional role (e.g., `[manager, invoice_manager]`), not to invent a new role like `manager_with_invoices` or to add another role to the command's allow-list. Roles stay small and composable; commands stay stable.
+
+Listing both `permission` and `roles` per command was considered and rejected — the redundancy reintroduces exactly the role explosion the split is meant to avoid.
+
+### `null` Permission = Public; Missing Entry = Throw
+
+A command/query entry maps to one of:
+- A permission string → authentication required, permission checked.
+- `null` → explicit public, dispatched without authentication.
+- (Missing key) → `SecurityConfigurationException` at dispatch time. **Fail closed.**
+
+A separate `public_commands` allow-list was considered and rejected. It creates two categories of "okay" — declared public (no entry needed) versus declared with permission — that drift independently and can hide forgotten registrations. With the unified map and explicit `null`, declaring a command public is one line right next to other declarations, and forgetting to register a new command produces a loud failure on first dispatch.
+
+A two-bus split (one secured bus, one public bus) was considered and rejected. Marketing has many public routes — forcing public controllers to inject a different bus type creates real friction for the common case, and the fail-closed property is preserved by the `null`-vs-missing rule without needing a separate bus.
+
+### Per-Audience Configs Composed via Registry
+
+Each audience owns a `SecurityConfigInterface` implementation declaring its commands, queries, and roles. Audiences live under `backend/src/Audience/` (`Audience\Admin\…`, `Audience\Partner\…`, future `Audience\Customer\…`). Configs are composed at DI wiring time via a `SecurityConfigRegistryInterface` (mirrors `CommandHandlerRegistryInterface` from ADR-006). A `CompositeSecurityConfig` merges entries; duplicate command/query keys throw at first lookup; role permissions union and de-duplicate.
+
+Bounded contexts (`backend/src/Crm/`, `backend/src/Marketing/`) own **only domain code** — aggregates, domain events, repositories interfaces. They contribute nothing to security configs. Commands and queries live in audiences and operate on bounded-context aggregates by calling their domain methods. The same conceptual operation (e.g., creating a lead) typically has separate command classes per audience — `Audience\Admin\…\CreateLeadCommand` vs `Audience\Partner\…\CreateLeadCommand` — because the surrounding concerns differ (history records, originator stamping, additional validations).
+
+Permissions are audience-scoped by convention: `admin.invoice.create`, `partner.lead.create`. Roles in one audience config never reference permission strings owned by another audience — preserving fail-closed semantics across audiences.
+
+A single composite is consulted for every dispatch — there is no per-user-type dispatch in the decorator. User type lives on `AuthenticatedUser` for informational purposes (logging, throttle tier resolution per ADR-007) but is not a key in the security lookup. Authorization is purely role→permission, regardless of which audience the user belongs to.
+
+### Security Interfaces Live in Domain
+
+Both `SecurityConfigInterface` and `SecurityConfigRegistryInterface` live in `SharedKernel\Domain\Security\` alongside `AuthorizationServiceInterface` and `SecurityContextInterface`. Neither has framework dependencies — both are pure contracts. Concrete implementations (`CompositeSecurityConfig`, `SecurityConfigFactory`, `ConfigAuthorizationService`) live in `SharedKernel\Infrastructure\Security\`.
+
+The codebase's existing `CommandHandlerRegistryInterface` (ADR-006) currently lives in Infrastructure, which is an inconsistency with this rule. Migrating it to Domain is tracked as a separate refactor; the inconsistency is small and isolated.
+
+### Authentication is Per-Driver, Hidden Behind `UserResolverInterface`
+
+A single domain interface — `UserResolverInterface::resolve(): ?AuthenticatedUser` — hides how the current user is identified for a request. Each framework/driver provides its own implementation:
+- FuelPHP partner portal: `FuelPhpAuthUserResolver` reads the SimpleAuth driver via `\Auth::check()`, `\Auth::instance()->get_user_id()` / `get_email()`, and `\Auth::group()->get_roles()`. Roles are the string names declared in `simpleauth.groups[<id>].roles`.
+- Future Cognito admin: a JWT-verifying resolver reads claims from the `Authorization` header.
+- Future Laravel customer: a resolver calling `Auth::user()`.
+
+Login is **not** abstracted. Each module's login flow is framework-specific by definition; trying to share a login interface across drivers conflates separate concerns. The seam is the resolver, not login.
+
+A session-key indirection (login writes four keys, resolver reads them) was considered and rejected for the FuelPHP partner case. Going through `\Auth` directly is simpler given SimpleAuth is the chosen dev driver, and each future driver (Cognito, Laravel) writes its own resolver regardless. The resolver is partner-specific today; admin and customer resolvers will be added when those modules exist.
+
+### Decorator Chain Order
+
+Outermost to innermost on the command bus:
+
+```
+Throttle → Security → Logger → Transaction → Handler
+```
+
+Queries omit Transaction. Rationale:
+- **Throttle outermost** — rate-limited requests don't reach authorization logic; throttle errors aren't masked as auth errors.
+- **Security before Logger** — failed authorization is logged via the existing `*LoggerDecorator` catching `Throwable`. One decorator, one job.
+- **Security before Transaction** — a denied command never opens a DB transaction.
+
+### Scaling the Audience Config
+
+A flat `AdminSecurityConfig` works while an audience has a small command/query surface. As the surface grows (estimate: ~30 commands per audience or ~300 lines in the config file), the file becomes hard to scan and PRs that touch a single feature area produce noisy diffs. The known refactor at that point is to split the config into per-feature permission groups and per-role classes, with the top-level config doing only composition.
+
+Sketch:
+
+```
+backend/src/Audience/Admin/Infrastructure/Security/
+├── AdminSecurityConfig.php             ← composes the parts; ~50 lines regardless of size
+├── AdminSecurityConfigRegistry.php
+├── Permissions/
+│   ├── InvoicePermissions.php          ← constants + commandPermissions() + queryPermissions() + readOnly()/full() bundles
+│   ├── UserPermissions.php
+│   ├── LeadPermissions.php
+│   └── ...
+└── Roles/
+    ├── AdminRole.php                   ← NAME constant + permissions() composing across feature groups
+    ├── StaffRole.php
+    ├── StaffInvoiceRole.php
+    └── OutsourcerRole.php
+```
+
+`AdminSecurityConfig` becomes:
+
+```php
+public function getCommandPermissions(): array
+{
+    return array_merge(
+        InvoicePermissions::commandPermissions(),
+        UserPermissions::commandPermissions(),
+        // ...
+    );
+}
+
+public function getRolePermissions(): array
+{
+    return [
+        AdminRole::NAME        => ['*'],
+        StaffRole::NAME        => StaffRole::permissions(),
+        StaffInvoiceRole::NAME => StaffInvoiceRole::permissions(),
+    ];
+}
+```
+
+A role like `StaffRole::permissions()` reads as composition over feature areas (`array_merge(InvoicePermissions::readOnly(), UserPermissions::readOnly(), …)`) instead of a flat list of dozens of permission strings.
+
+This is **not** done today — the audience configs are minimal stubs. The pattern is documented here so the refactor target is known; the migration is mechanical when the time comes.
+
+### Out of Scope
+
+The following are explicitly **not** part of this module:
+
+- **Login / credential verification** — per-framework concern. Each module's login controller writes whatever its driver requires.
+- **Session and token refresh management** — framework concern. SimpleAuth's session machinery, Cognito's refresh tokens, and Laravel's session driver are each their framework's responsibility.
+- **Audit logging subsystem** — the existing `CommandLoggerDecorator` and `QueryLoggerDecorator` log every dispatch including thrown exceptions. A dedicated `SecurityAuditLoggerInterface` would duplicate this responsibility.
+- **Per-instance policies** (e.g., "admin can edit users, but only in their own partner org") — deferred. The architecture allows extension: the decorator can later consult an optional `PolicyResolverInterface` after the permission check passes. No code today.
+- **Row scoping** ("partner manager sees only invoices for their org") — not the security module's job. Query handlers receive `SecurityContext`, read the current user, and pass scope to repositories. A generic post-filtering decorator was considered and rejected: it breaks pagination and counts, hits performance, and re-implements per-entity knowledge already in repositories.
+- **Field masking / sensitive-field redaction** — presentation-layer concern. A domain object should always carry its real values; redaction belongs in the API resource / view-model layer that serializes to the caller.
+- **Standardized error message handling** — exceptions carry technical info; the HTTP layer maps them to generic 401 / 403 responses. A dedicated security error handler would duplicate the HTTP layer's responsibility.
+
+## Components
+
+| Component | Layer | Purpose |
+|---|---|---|
+| `AuthenticatedUser` | Domain | Value object: id, email, roles, type. `hasRole(string): bool` helper. |
+| `UserType` | Domain | Constants: ADMIN, PARTNER, CUSTOMER, ANONYMOUS. |
+| `SecurityContextInterface` | Domain | Request-scoped current user. |
+| `UserResolverInterface` | Domain | Per-driver seam: `resolve(): ?AuthenticatedUser`. |
+| `AuthorizationServiceInterface` | Domain | `isAllowed(AuthenticatedUser, string $permission): bool`. |
+| `SecurityConfigInterface` | Domain | `getCommandPermissions()`, `getQueryPermissions()`, `getRolePermissions()`. |
+| `UnauthenticatedException` | Domain | Permission required, no user in context. Extends `RuntimeException`. |
+| `UnauthorizedException` | Domain | User present, lacks permission. Carries `getRequiredPermission()`. |
+| `SecurityConfigurationException` | Domain | Command/query not registered in any config. Extends `LogicException`. |
+| `SecurityConfigRegistryInterface` | Domain | Composition seam — audiences contribute via this. |
+| `CompositeSecurityConfig` | Infrastructure | Merges per-context configs; throws on duplicate command/query keys; unions roles. |
+| `SecurityConfigFactory` | Infrastructure | `__invoke()`-style factory taking registries, returns composite. |
+| `ConfigAuthorizationService` | Infrastructure | Walks user roles against config; supports `*` wildcard. |
+| `SecurityCommandDecorator` | Infrastructure | `CommandBusInterface` decorator; enforces config-based authorization at dispatch. |
+| `SecurityQueryDecorator` | Infrastructure | `QueryBusInterface` decorator; same logic, different return type. |
+| `FuelPhpSecurityContext` | FuelPHP infra | Per-request `SecurityContext` storage. |
+| `FuelPhpAuthUserResolver` | FuelPHP infra | Reads SimpleAuth via `\Auth::check()` / `\Auth::instance()` / `\Auth::group()`. |
+| `AdminSecurityConfig` + `AdminSecurityConfigRegistry` | Admin audience | Roles `admin`, `staff`, `outsourcer`, `staff_invoice`; commands/queries to be added. |
+| `PartnerSecurityConfig` + `PartnerSecurityConfigRegistry` | Partner audience | Roles `partner_owner`, `partner_member`; commands/queries to be added. |
+
+## Consequences
+
+### Positive
+
+- Permission-only authorization scales without role explosion — adding cross-cutting access means assigning an existing role, not editing every affected command.
+- Fail-closed-by-default: forgetting to register a new command fails loudly on first dispatch, not silently in production.
+- Per-bounded-context configs preserve DDD ownership boundaries — context teams edit their own files only.
+- Composition pattern matches the existing `CommandHandlerRegistryInterface` shape — one mental model for both handler registration and security config.
+- Per-driver resolvers cleanly separate "which framework auth?" from "what permissions?" — the same `AuthenticatedUser` flows through to identical CQRS authorization regardless of driver.
+- Decorator chain order ensures denied commands don't open transactions or get logged as successes.
+- Out-of-scope decisions (audit, masking, row scoping, policies) keep the module's surface area small and intentional.
+
+### Trade-offs
+
+- Some logic duplication between `SecurityCommandDecorator` and `SecurityQueryDecorator` — the two operate on different bus interfaces with different return types (`void` vs `QueryResponseInterface`), so a shared trait or base class would obscure two small bodies for negligible reuse benefit. Two ~40-line classes is the lesser evil.
+- One `SecurityConfig` file per audience — config grows linearly with audiences (small, fixed set: admin, partner, customer). Acceptable.
+- Row scoping is deferred to query handlers individually — requires consistent discipline across handler authors. A generic decorator was rejected as the wrong tool, but the cost is that "filter by tenant" logic isn't centralized.
+- Role names are strings — typos in `getRolePermissions()` keys vs. role assignments produce silent denials, not boot-time errors. Mitigated by per-audience constants (e.g., `AdminSecurityConfig::ROLE_ADMIN = 'admin'`) but not enforced.
+- Permission strings are similarly typo-prone. Mitigated by per-context constants but not enforced.
+
+### Deferred Decisions
+
+These are real questions raised during design that were intentionally not resolved:
+
+- **Multi-user-type session collision in dev.** When SimpleAuth is used for admin, partner, and customer simultaneously in the same browser, the default Auth instance and shared session keys conflict. Likely fix: namespaced session keys per user type (`admin.user_id`, `partner.user_id`, …) or named Auth instances (`\Auth::instance('admin')`). Not relevant until admin and customer modules exist alongside partner.
+- **Idle session timeout for authenticated users.** PHP sessions have one lifetime per session, not per key. If authenticated sessions need a different (typically shorter) idle window than anonymous sessions, the resolver must enforce a `last_activity` timestamp and clear the user's session keys when stale. Not implemented; defer until a real requirement (e.g., admin panel inactivity timeout) materializes.
+- **Env-based resolver swap (SimpleAuth dev → Cognito prod for admin).** When admin moves to Cognito in production, the admin resolver binding must vary by environment. Likely shape: a marker interface (`AdminUserResolverInterface`) bound via env-conditional DI factory. Not built today because no second admin implementation exists yet — adding the marker interface for one implementation would be premature.
+- **Where `Package::load('auth')` lives.** Currently called in the partner abstract controller's `before()` to lazy-load the FuelPHP Auth package. When more controllers need it, consider moving the call into the resolver itself so the controller stays neutral. Not a blocker; current placement works.
+
+### Future Work
+
+- `CognitoJwtUserResolver` for admin panel when admin module lands in production.
+- Laravel `UserResolverInterface` implementation when the Laravel layer reaches authenticated CQRS calls.
+- Customer audience security config (currently only Admin and Partner are wired).
+- Per-instance policy extension point if/when contextual checks become necessary. The decorator can resolve an optional `PolicyResolverInterface` per command FQCN and invoke `$policy->check($user, $command)` after permission passes — no breaking changes required.

--- a/backend/src/Audience/Admin/Infrastructure/Security/AdminSecurityConfig.php
+++ b/backend/src/Audience/Admin/Infrastructure/Security/AdminSecurityConfig.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Audience\Admin\Infrastructure\Security;
+
+use SharedKernel\Domain\Security\SecurityConfigInterface;
+
+final class AdminSecurityConfig implements SecurityConfigInterface
+{
+    public const ROLE_ADMIN = 'admin';
+    public const ROLE_STAFF = 'staff';
+    public const ROLE_OUTSOURCER = 'outsourcer';
+    public const ROLE_STAFF_INVOICE = 'staff_invoice';
+
+    public function getCommandPermissions(): array
+    {
+        // TODO: register Admin commands here, e.g.
+        //   CreateInvoiceCommand::class => 'admin.invoice.create',
+        return [];
+    }
+
+    public function getQueryPermissions(): array
+    {
+        // TODO: register Admin queries here, e.g.
+        //   GetInvoiceQuery::class => 'admin.invoice.view',
+        return [];
+    }
+
+    public function getRolePermissions(): array
+    {
+        return [
+            self::ROLE_ADMIN => ['*'],
+            self::ROLE_STAFF => [],
+            self::ROLE_OUTSOURCER => [],
+            self::ROLE_STAFF_INVOICE => [],
+        ];
+    }
+}

--- a/backend/src/Audience/Admin/Infrastructure/Security/AdminSecurityConfigRegistry.php
+++ b/backend/src/Audience/Admin/Infrastructure/Security/AdminSecurityConfigRegistry.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Audience\Admin\Infrastructure\Security;
+
+use SharedKernel\Domain\Security\SecurityConfigRegistryInterface;
+
+final class AdminSecurityConfigRegistry implements SecurityConfigRegistryInterface
+{
+    private AdminSecurityConfig $config;
+
+    public function __construct(AdminSecurityConfig $config)
+    {
+        $this->config = $config;
+    }
+
+    public function getSecurityConfigs(): array
+    {
+        return [$this->config];
+    }
+}

--- a/backend/src/Audience/Partner/Infrastructure/Security/PartnerSecurityConfig.php
+++ b/backend/src/Audience/Partner/Infrastructure/Security/PartnerSecurityConfig.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Audience\Partner\Infrastructure\Security;
+
+use SharedKernel\Domain\Security\SecurityConfigInterface;
+
+final class PartnerSecurityConfig implements SecurityConfigInterface
+{
+    public const ROLE_OWNER = 'partner_owner';
+    public const ROLE_MEMBER = 'partner_member';
+
+    public function getCommandPermissions(): array
+    {
+        // TODO: register Partner commands here, e.g.
+        //   CreateLeadCommand::class => 'partner.lead.create',
+        return [];
+    }
+
+    public function getQueryPermissions(): array
+    {
+        // TODO: register Partner queries here, e.g.
+        //   GetLeadListQuery::class => 'partner.lead.list',
+        return [];
+    }
+
+    public function getRolePermissions(): array
+    {
+        return [
+            self::ROLE_OWNER => [],
+            self::ROLE_MEMBER => [],
+        ];
+    }
+}

--- a/backend/src/Audience/Partner/Infrastructure/Security/PartnerSecurityConfigRegistry.php
+++ b/backend/src/Audience/Partner/Infrastructure/Security/PartnerSecurityConfigRegistry.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Audience\Partner\Infrastructure\Security;
+
+use SharedKernel\Domain\Security\SecurityConfigRegistryInterface;
+
+final class PartnerSecurityConfigRegistry implements SecurityConfigRegistryInterface
+{
+    private PartnerSecurityConfig $config;
+
+    public function __construct(PartnerSecurityConfig $config)
+    {
+        $this->config = $config;
+    }
+
+    public function getSecurityConfigs(): array
+    {
+        return [$this->config];
+    }
+}

--- a/backend/src/SharedKernel/Domain/Security/AuthenticatedUser.php
+++ b/backend/src/SharedKernel/Domain/Security/AuthenticatedUser.php
@@ -41,6 +41,11 @@ final class AuthenticatedUser
         return $this->roles;
     }
 
+    public function hasRole(string $role): bool
+    {
+        return in_array($role, $this->roles, true);
+    }
+
     public function getType(): string
     {
         return $this->type;

--- a/backend/src/SharedKernel/Domain/Security/Exception/SecurityConfigurationException.php
+++ b/backend/src/SharedKernel/Domain/Security/Exception/SecurityConfigurationException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Domain\Security\Exception;
+
+use LogicException;
+
+class SecurityConfigurationException extends LogicException
+{
+    public static function commandNotRegistered(string $commandClass): self
+    {
+        return new self("No security configuration found for command: $commandClass");
+    }
+
+    public static function queryNotRegistered(string $queryClass): self
+    {
+        return new self("No security configuration found for query: $queryClass");
+    }
+
+    public static function duplicateCommandEntry(string $commandClass): self
+    {
+        return new self("Duplicate security configuration entry for command: $commandClass");
+    }
+
+    public static function duplicateQueryEntry(string $queryClass): self
+    {
+        return new self("Duplicate security configuration entry for query: $queryClass");
+    }
+}

--- a/backend/src/SharedKernel/Domain/Security/Exception/UnauthenticatedException.php
+++ b/backend/src/SharedKernel/Domain/Security/Exception/UnauthenticatedException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Domain\Security\Exception;
+
+use RuntimeException;
+
+class UnauthenticatedException extends RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('Authentication required');
+    }
+}

--- a/backend/src/SharedKernel/Domain/Security/Exception/UnauthorizedException.php
+++ b/backend/src/SharedKernel/Domain/Security/Exception/UnauthorizedException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Domain\Security\Exception;
+
+use RuntimeException;
+
+class UnauthorizedException extends RuntimeException
+{
+    private string $requiredPermission;
+
+    public function __construct(string $requiredPermission)
+    {
+        parent::__construct('Access denied');
+        $this->requiredPermission = $requiredPermission;
+    }
+
+    public function getRequiredPermission(): string
+    {
+        return $this->requiredPermission;
+    }
+}

--- a/backend/src/SharedKernel/Domain/Security/SecurityConfigInterface.php
+++ b/backend/src/SharedKernel/Domain/Security/SecurityConfigInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Domain\Security;
+
+interface SecurityConfigInterface
+{
+    /**
+     * Map of command FQCN to the required permission name.
+     * A null value declares the command as explicitly public (no authentication required).
+     * A missing entry causes SecurityConfigurationException at dispatch time (fail closed).
+     *
+     * @return array<class-string, string|null>
+     */
+    public function getCommandPermissions(): array;
+
+    /**
+     * Map of query FQCN to the required permission name. Same semantics as command permissions.
+     *
+     * @return array<class-string, string|null>
+     */
+    public function getQueryPermissions(): array;
+
+    /**
+     * Map of role name to the list of permissions that role grants.
+     * The wildcard '*' grants every permission.
+     *
+     * @return array<string, array<string>>
+     */
+    public function getRolePermissions(): array;
+}

--- a/backend/src/SharedKernel/Domain/Security/SecurityConfigRegistryInterface.php
+++ b/backend/src/SharedKernel/Domain/Security/SecurityConfigRegistryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Domain\Security;
+
+interface SecurityConfigRegistryInterface
+{
+    /**
+     * Return the security configurations contributed by this audience.
+     *
+     * @return SecurityConfigInterface[]
+     */
+    public function getSecurityConfigs(): array;
+}

--- a/backend/src/SharedKernel/Domain/Security/UserResolverInterface.php
+++ b/backend/src/SharedKernel/Domain/Security/UserResolverInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Domain\Security;
+
+interface UserResolverInterface
+{
+    /**
+     * Resolve the authenticated user for the current request, session, or token.
+     * Implementations are framework-specific (FuelPHP session, Cognito JWT, Laravel auth, etc.).
+     *
+     * @return AuthenticatedUser|null Null when no user is authenticated.
+     */
+    public function resolve(): ?AuthenticatedUser;
+}

--- a/backend/src/SharedKernel/Domain/Security/UserType.php
+++ b/backend/src/SharedKernel/Domain/Security/UserType.php
@@ -9,7 +9,6 @@ final class UserType
     public const ADMIN = 'admin';
     public const PARTNER = 'partner';
     public const CUSTOMER = 'customer';
-    public const SYSTEM = 'system';
     public const ANONYMOUS = 'anonymous';
 
     /** @var array<string> */
@@ -17,7 +16,6 @@ final class UserType
         self::ADMIN,
         self::PARTNER,
         self::CUSTOMER,
-        self::SYSTEM,
         self::ANONYMOUS,
     ];
 

--- a/backend/src/SharedKernel/Infrastructure/CqrsMessageBus/Decorators/SecurityCommandDecorator.php
+++ b/backend/src/SharedKernel/Infrastructure/CqrsMessageBus/Decorators/SecurityCommandDecorator.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Infrastructure\CqrsMessageBus\Decorators;
+
+use SharedKernel\Application\CqrsMessageBus\Commands\CommandBusInterface;
+use SharedKernel\Application\CqrsMessageBus\Commands\CommandInterface;
+use SharedKernel\Domain\Security\AuthorizationServiceInterface;
+use SharedKernel\Domain\Security\Exception\SecurityConfigurationException;
+use SharedKernel\Domain\Security\Exception\UnauthenticatedException;
+use SharedKernel\Domain\Security\Exception\UnauthorizedException;
+use SharedKernel\Domain\Security\SecurityConfigInterface;
+use SharedKernel\Domain\Security\SecurityContextInterface;
+
+final class SecurityCommandDecorator implements CommandBusInterface
+{
+    private CommandBusInterface $inner;
+    private SecurityContextInterface $securityContext;
+    private AuthorizationServiceInterface $authorizationService;
+    private SecurityConfigInterface $securityConfig;
+
+    public function __construct(
+        CommandBusInterface $inner,
+        SecurityContextInterface $securityContext,
+        AuthorizationServiceInterface $authorizationService,
+        SecurityConfigInterface $securityConfig
+    ) {
+        $this->inner = $inner;
+        $this->securityContext = $securityContext;
+        $this->authorizationService = $authorizationService;
+        $this->securityConfig = $securityConfig;
+    }
+
+    public function dispatch(CommandInterface $command): void
+    {
+        $commandClass = get_class($command);
+        $permissions = $this->securityConfig->getCommandPermissions();
+
+        if (!array_key_exists($commandClass, $permissions)) {
+            throw SecurityConfigurationException::commandNotRegistered($commandClass);
+        }
+
+        $permission = $permissions[$commandClass];
+        if ($permission === null) {
+            $this->inner->dispatch($command);
+            return;
+        }
+
+        $user = $this->securityContext->getCurrentUser();
+        if ($user === null) {
+            throw new UnauthenticatedException();
+        }
+
+        if (!$this->authorizationService->isAllowed($user, $permission)) {
+            throw new UnauthorizedException($permission);
+        }
+
+        $this->inner->dispatch($command);
+    }
+}

--- a/backend/src/SharedKernel/Infrastructure/CqrsMessageBus/Decorators/SecurityQueryDecorator.php
+++ b/backend/src/SharedKernel/Infrastructure/CqrsMessageBus/Decorators/SecurityQueryDecorator.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Infrastructure\CqrsMessageBus\Decorators;
+
+use SharedKernel\Application\CqrsMessageBus\Queries\QueryBusInterface;
+use SharedKernel\Application\CqrsMessageBus\Queries\QueryInterface;
+use SharedKernel\Application\CqrsMessageBus\Queries\QueryResponseInterface;
+use SharedKernel\Domain\Security\AuthorizationServiceInterface;
+use SharedKernel\Domain\Security\Exception\SecurityConfigurationException;
+use SharedKernel\Domain\Security\Exception\UnauthenticatedException;
+use SharedKernel\Domain\Security\Exception\UnauthorizedException;
+use SharedKernel\Domain\Security\SecurityConfigInterface;
+use SharedKernel\Domain\Security\SecurityContextInterface;
+
+// Logic intentionally duplicates SecurityCommandDecorator: the two operate on different
+// interfaces with different return types (void vs QueryResponseInterface), so a shared
+// trait or base would obscure two small bodies for negligible reuse benefit.
+final class SecurityQueryDecorator implements QueryBusInterface
+{
+    private QueryBusInterface $inner;
+    private SecurityContextInterface $securityContext;
+    private AuthorizationServiceInterface $authorizationService;
+    private SecurityConfigInterface $securityConfig;
+
+    public function __construct(
+        QueryBusInterface $inner,
+        SecurityContextInterface $securityContext,
+        AuthorizationServiceInterface $authorizationService,
+        SecurityConfigInterface $securityConfig
+    ) {
+        $this->inner = $inner;
+        $this->securityContext = $securityContext;
+        $this->authorizationService = $authorizationService;
+        $this->securityConfig = $securityConfig;
+    }
+
+    public function dispatch(QueryInterface $query): QueryResponseInterface
+    {
+        $queryClass = get_class($query);
+        $permissions = $this->securityConfig->getQueryPermissions();
+
+        if (!array_key_exists($queryClass, $permissions)) {
+            throw SecurityConfigurationException::queryNotRegistered($queryClass);
+        }
+
+        $permission = $permissions[$queryClass];
+        if ($permission === null) {
+            return $this->inner->dispatch($query);
+        }
+
+        $user = $this->securityContext->getCurrentUser();
+        if ($user === null) {
+            throw new UnauthenticatedException();
+        }
+
+        if (!$this->authorizationService->isAllowed($user, $permission)) {
+            throw new UnauthorizedException($permission);
+        }
+
+        return $this->inner->dispatch($query);
+    }
+}

--- a/backend/src/SharedKernel/Infrastructure/Security/CompositeSecurityConfig.php
+++ b/backend/src/SharedKernel/Infrastructure/Security/CompositeSecurityConfig.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Infrastructure\Security;
+
+use SharedKernel\Domain\Security\Exception\SecurityConfigurationException;
+use SharedKernel\Domain\Security\SecurityConfigInterface;
+
+final class CompositeSecurityConfig implements SecurityConfigInterface
+{
+    /** @var SecurityConfigInterface[] */
+    private array $configs;
+
+    /** @var array<class-string, string|null>|null */
+    private ?array $commandPermissions = null;
+
+    /** @var array<class-string, string|null>|null */
+    private ?array $queryPermissions = null;
+
+    /** @var array<string, array<string>>|null */
+    private ?array $rolePermissions = null;
+
+    /**
+     * @param SecurityConfigInterface[] $configs
+     */
+    public function __construct(array $configs)
+    {
+        $this->configs = $configs;
+    }
+
+    public function getCommandPermissions(): array
+    {
+        if ($this->commandPermissions === null) {
+            $this->commandPermissions = $this->mergeOperationPermissions(true);
+        }
+
+        return $this->commandPermissions;
+    }
+
+    public function getQueryPermissions(): array
+    {
+        if ($this->queryPermissions === null) {
+            $this->queryPermissions = $this->mergeOperationPermissions(false);
+        }
+
+        return $this->queryPermissions;
+    }
+
+    public function getRolePermissions(): array
+    {
+        if ($this->rolePermissions === null) {
+            $merged = [];
+            foreach ($this->configs as $config) {
+                foreach ($config->getRolePermissions() as $role => $permissions) {
+                    if (!isset($merged[$role])) {
+                        $merged[$role] = [];
+                    }
+                    foreach ($permissions as $permission) {
+                        $merged[$role][] = $permission;
+                    }
+                }
+            }
+            foreach ($merged as $role => $permissions) {
+                $merged[$role] = array_values(array_unique($permissions));
+            }
+            $this->rolePermissions = $merged;
+        }
+
+        return $this->rolePermissions;
+    }
+
+    /**
+     * @return array<class-string, string|null>
+     */
+    private function mergeOperationPermissions(bool $forCommands): array
+    {
+        $merged = [];
+        foreach ($this->configs as $config) {
+            $entries = $forCommands ? $config->getCommandPermissions() : $config->getQueryPermissions();
+            foreach ($entries as $class => $permission) {
+                if (array_key_exists($class, $merged)) {
+                    throw $forCommands
+                        ? SecurityConfigurationException::duplicateCommandEntry($class)
+                        : SecurityConfigurationException::duplicateQueryEntry($class);
+                }
+                $merged[$class] = $permission;
+            }
+        }
+
+        return $merged;
+    }
+}

--- a/backend/src/SharedKernel/Infrastructure/Security/ConfigAuthorizationService.php
+++ b/backend/src/SharedKernel/Infrastructure/Security/ConfigAuthorizationService.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Infrastructure\Security;
+
+use SharedKernel\Domain\Security\AuthenticatedUser;
+use SharedKernel\Domain\Security\AuthorizationServiceInterface;
+use SharedKernel\Domain\Security\SecurityConfigInterface;
+
+final class ConfigAuthorizationService implements AuthorizationServiceInterface
+{
+    public const PERMISSION_WILDCARD = '*';
+
+    private SecurityConfigInterface $config;
+
+    public function __construct(SecurityConfigInterface $config)
+    {
+        $this->config = $config;
+    }
+
+    public function isAllowed(AuthenticatedUser $user, string $permission): bool
+    {
+        $rolePermissions = $this->config->getRolePermissions();
+
+        foreach ($user->getRoles() as $role) {
+            $granted = $rolePermissions[$role] ?? [];
+            if (in_array(self::PERMISSION_WILDCARD, $granted, true)) {
+                return true;
+            }
+            if (in_array($permission, $granted, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/backend/src/SharedKernel/Infrastructure/Security/SecurityConfigFactory.php
+++ b/backend/src/SharedKernel/Infrastructure/Security/SecurityConfigFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Infrastructure\Security;
+
+use SharedKernel\Domain\Security\SecurityConfigInterface;
+use SharedKernel\Domain\Security\SecurityConfigRegistryInterface;
+
+final class SecurityConfigFactory
+{
+    /** @var SecurityConfigRegistryInterface[] */
+    private array $registries;
+
+    /**
+     * @param SecurityConfigRegistryInterface[] $registries
+     */
+    public function __construct(array $registries)
+    {
+        $this->registries = $registries;
+    }
+
+    public function __invoke(): SecurityConfigInterface
+    {
+        $configs = [];
+        foreach ($this->registries as $registry) {
+            foreach ($registry->getSecurityConfigs() as $config) {
+                $configs[] = $config;
+            }
+        }
+
+        return new CompositeSecurityConfig($configs);
+    }
+}

--- a/backend/src/SharedKernel/Infrastructure/Throttle/ThrottleConfigDefaults.php
+++ b/backend/src/SharedKernel/Infrastructure/Throttle/ThrottleConfigDefaults.php
@@ -16,7 +16,6 @@ final class ThrottleConfigDefaults
         return [
             'defaults' => [
                 UserType::ADMIN => null,
-                UserType::SYSTEM => null,
                 UserType::PARTNER => [
                     'warning_limit' => 100,
                     'block_limit' => 200,

--- a/backend/tests/Fixtures/SharedKernel/CqrsMessageBus/SecondTestCommand.php
+++ b/backend/tests/Fixtures/SharedKernel/CqrsMessageBus/SecondTestCommand.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\SharedKernel\CqrsMessageBus;
+
+use SharedKernel\Application\CqrsMessageBus\Commands\CommandInterface;
+
+final class SecondTestCommand implements CommandInterface
+{
+}

--- a/backend/tests/Fixtures/SharedKernel/CqrsMessageBus/SecondTestQuery.php
+++ b/backend/tests/Fixtures/SharedKernel/CqrsMessageBus/SecondTestQuery.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\SharedKernel\CqrsMessageBus;
+
+use SharedKernel\Application\CqrsMessageBus\Queries\QueryInterface;
+
+/**
+ * @implements QueryInterface<TestQueryResponse>
+ */
+final class SecondTestQuery implements QueryInterface
+{
+}

--- a/backend/tests/Fixtures/SharedKernel/CqrsMessageBus/ThirdTestCommand.php
+++ b/backend/tests/Fixtures/SharedKernel/CqrsMessageBus/ThirdTestCommand.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\SharedKernel\CqrsMessageBus;
+
+use SharedKernel\Application\CqrsMessageBus\Commands\CommandInterface;
+
+final class ThirdTestCommand implements CommandInterface
+{
+}

--- a/backend/tests/Fixtures/SharedKernel/Security/CountingSecurityConfig.php
+++ b/backend/tests/Fixtures/SharedKernel/Security/CountingSecurityConfig.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\SharedKernel\Security;
+
+use SharedKernel\Domain\Security\SecurityConfigInterface;
+use Tests\Fixtures\SharedKernel\CqrsMessageBus\TestCommand;
+use Tests\Fixtures\SharedKernel\CqrsMessageBus\TestQuery;
+
+final class CountingSecurityConfig implements SecurityConfigInterface
+{
+    public int $commandCalls = 0;
+    public int $queryCalls = 0;
+    public int $roleCalls = 0;
+
+    public function getCommandPermissions(): array
+    {
+        $this->commandCalls++;
+        return [TestCommand::class => 'do'];
+    }
+
+    public function getQueryPermissions(): array
+    {
+        $this->queryCalls++;
+        return [TestQuery::class => 'read'];
+    }
+
+    public function getRolePermissions(): array
+    {
+        $this->roleCalls++;
+        return ['viewer' => ['read']];
+    }
+}

--- a/backend/tests/Fixtures/SharedKernel/Security/SpyQueryBus.php
+++ b/backend/tests/Fixtures/SharedKernel/Security/SpyQueryBus.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\SharedKernel\Security;
+
+use SharedKernel\Application\CqrsMessageBus\Queries\QueryBusInterface;
+use SharedKernel\Application\CqrsMessageBus\Queries\QueryInterface;
+use SharedKernel\Application\CqrsMessageBus\Queries\QueryResponseInterface;
+
+final class SpyQueryBus implements QueryBusInterface
+{
+    public int $dispatched = 0;
+    public ?QueryInterface $lastQuery = null;
+    private QueryResponseInterface $response;
+
+    public function __construct(?QueryResponseInterface $response = null)
+    {
+        $this->response = $response ?? new class implements QueryResponseInterface {
+        };
+    }
+
+    public function dispatch(QueryInterface $query): QueryResponseInterface
+    {
+        $this->dispatched++;
+        $this->lastQuery = $query;
+        return $this->response;
+    }
+}

--- a/backend/tests/Unit/Audience/Admin/Infrastructure/Security/AdminSecurityConfigTest.php
+++ b/backend/tests/Unit/Audience/Admin/Infrastructure/Security/AdminSecurityConfigTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Audience\Admin\Infrastructure\Security;
+
+use Audience\Admin\Infrastructure\Security\AdminSecurityConfig;
+use PHPUnit\Framework\TestCase;
+
+class AdminSecurityConfigTest extends TestCase
+{
+    public function testCommandAndQueryPermissionsAreEmptyForNow(): void
+    {
+        $config = new AdminSecurityConfig();
+
+        $this->assertSame([], $config->getCommandPermissions());
+        $this->assertSame([], $config->getQueryPermissions());
+    }
+
+    public function testAdminRoleHasWildcardPermission(): void
+    {
+        $config = new AdminSecurityConfig();
+        $roles = $config->getRolePermissions();
+
+        $this->assertSame(['*'], $roles[AdminSecurityConfig::ROLE_ADMIN]);
+    }
+
+    public function testStaffOutsourcerAndStaffInvoiceRolesExistWithEmptyPermissionsForNow(): void
+    {
+        $config = new AdminSecurityConfig();
+        $roles = $config->getRolePermissions();
+
+        $this->assertArrayHasKey(AdminSecurityConfig::ROLE_STAFF, $roles);
+        $this->assertArrayHasKey(AdminSecurityConfig::ROLE_OUTSOURCER, $roles);
+        $this->assertArrayHasKey(AdminSecurityConfig::ROLE_STAFF_INVOICE, $roles);
+        $this->assertSame([], $roles[AdminSecurityConfig::ROLE_STAFF]);
+        $this->assertSame([], $roles[AdminSecurityConfig::ROLE_OUTSOURCER]);
+        $this->assertSame([], $roles[AdminSecurityConfig::ROLE_STAFF_INVOICE]);
+    }
+}

--- a/backend/tests/Unit/Audience/Partner/Infrastructure/Security/PartnerSecurityConfigTest.php
+++ b/backend/tests/Unit/Audience/Partner/Infrastructure/Security/PartnerSecurityConfigTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Audience\Partner\Infrastructure\Security;
+
+use Audience\Partner\Infrastructure\Security\PartnerSecurityConfig;
+use PHPUnit\Framework\TestCase;
+
+class PartnerSecurityConfigTest extends TestCase
+{
+    public function testCommandAndQueryPermissionsAreEmptyForNow(): void
+    {
+        $config = new PartnerSecurityConfig();
+
+        $this->assertSame([], $config->getCommandPermissions());
+        $this->assertSame([], $config->getQueryPermissions());
+    }
+
+    public function testRolesAreDeclaredWithEmptyPermissionsForNow(): void
+    {
+        $config = new PartnerSecurityConfig();
+        $roles = $config->getRolePermissions();
+
+        $this->assertArrayHasKey(PartnerSecurityConfig::ROLE_OWNER, $roles);
+        $this->assertArrayHasKey(PartnerSecurityConfig::ROLE_MEMBER, $roles);
+        $this->assertSame([], $roles[PartnerSecurityConfig::ROLE_OWNER]);
+        $this->assertSame([], $roles[PartnerSecurityConfig::ROLE_MEMBER]);
+    }
+}

--- a/backend/tests/Unit/SharedKernel/Domain/Security/AuthenticatedUserTest.php
+++ b/backend/tests/Unit/SharedKernel/Domain/Security/AuthenticatedUserTest.php
@@ -25,29 +25,36 @@ class AuthenticatedUserTest extends TestCase
         $user = new AuthenticatedUser('1', 'user@example.com', ['user']);
 
         $this->assertSame(UserType::CUSTOMER, $user->getType());
+        $this->assertSame([], (new AuthenticatedUser('1', 'test@example.com'))->getRoles());
     }
 
-    public function testConstructionWithPartnerType(): void
+    public function testHasRoleReturnsTrueWhenRolePresent(): void
     {
-        $user = new AuthenticatedUser('10', 'partner@example.com', ['partner'], UserType::PARTNER);
+        $user = new AuthenticatedUser('1', 'a@example.com', ['admin', 'manager']);
 
-        $this->assertSame(UserType::PARTNER, $user->getType());
+        $this->assertTrue($user->hasRole('admin'));
+        $this->assertTrue($user->hasRole('manager'));
     }
 
-    public function testConstructionWithCustomerType(): void
+    public function testHasRoleReturnsFalseWhenRoleAbsent(): void
     {
-        $user = new AuthenticatedUser('20', 'customer@example.com', [], UserType::CUSTOMER);
+        $user = new AuthenticatedUser('1', 'a@example.com', ['admin']);
 
-        $this->assertSame(UserType::CUSTOMER, $user->getType());
+        $this->assertFalse($user->hasRole('manager'));
     }
 
-    public function testConstructionWithMinimalArguments(): void
+    public function testHasRoleReturnsFalseForEmptyRoleList(): void
     {
-        $user = new AuthenticatedUser('1', 'test@example.com');
+        $user = new AuthenticatedUser('1', 'a@example.com', []);
 
-        $this->assertSame('1', $user->getId());
-        $this->assertSame('test@example.com', $user->getEmail());
-        $this->assertSame([], $user->getRoles());
-        $this->assertSame(UserType::CUSTOMER, $user->getType());
+        $this->assertFalse($user->hasRole('admin'));
+    }
+
+    public function testHasRoleIsCaseSensitive(): void
+    {
+        $user = new AuthenticatedUser('1', 'a@example.com', ['Admin']);
+
+        $this->assertTrue($user->hasRole('Admin'));
+        $this->assertFalse($user->hasRole('admin'));
     }
 }

--- a/backend/tests/Unit/SharedKernel/Domain/Security/Exception/SecurityExceptionsTest.php
+++ b/backend/tests/Unit/SharedKernel/Domain/Security/Exception/SecurityExceptionsTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\SharedKernel\Domain\Security\Exception;
+
+use LogicException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use SharedKernel\Domain\Security\Exception\SecurityConfigurationException;
+use SharedKernel\Domain\Security\Exception\UnauthenticatedException;
+use SharedKernel\Domain\Security\Exception\UnauthorizedException;
+
+class SecurityExceptionsTest extends TestCase
+{
+    public function testUnauthenticatedException(): void
+    {
+        $e = new UnauthenticatedException();
+
+        $this->assertInstanceOf(RuntimeException::class, $e);
+        $this->assertSame('Authentication required', $e->getMessage());
+    }
+
+    public function testUnauthorizedExceptionExposesRequiredPermission(): void
+    {
+        $e = new UnauthorizedException('user.delete');
+
+        $this->assertInstanceOf(RuntimeException::class, $e);
+        $this->assertSame('user.delete', $e->getRequiredPermission());
+        $this->assertSame('Access denied', $e->getMessage());
+    }
+
+    /**
+     * @dataProvider securityConfigurationFactoryProvider
+     */
+    public function testSecurityConfigurationExceptionFactories(
+        SecurityConfigurationException $exception,
+        string $expectedClassFragment,
+        string $expectedKeywordFragment
+    ): void {
+        $this->assertInstanceOf(LogicException::class, $exception);
+        $this->assertStringContainsString($expectedClassFragment, $exception->getMessage());
+        $this->assertStringContainsString($expectedKeywordFragment, $exception->getMessage());
+    }
+
+    /**
+     * @return array<string, array{0: SecurityConfigurationException, 1: string, 2: string}>
+     */
+    public function securityConfigurationFactoryProvider(): array
+    {
+        return [
+            'commandNotRegistered' => [
+                SecurityConfigurationException::commandNotRegistered('App\\CreateFooCommand'),
+                'App\\CreateFooCommand',
+                'command',
+            ],
+            'queryNotRegistered' => [
+                SecurityConfigurationException::queryNotRegistered('App\\GetFooQuery'),
+                'App\\GetFooQuery',
+                'query',
+            ],
+            'duplicateCommandEntry' => [
+                SecurityConfigurationException::duplicateCommandEntry('App\\CreateFooCommand'),
+                'App\\CreateFooCommand',
+                'Duplicate',
+            ],
+            'duplicateQueryEntry' => [
+                SecurityConfigurationException::duplicateQueryEntry('App\\GetFooQuery'),
+                'App\\GetFooQuery',
+                'Duplicate',
+            ],
+        ];
+    }
+}

--- a/backend/tests/Unit/SharedKernel/Domain/Security/UserTypeTest.php
+++ b/backend/tests/Unit/SharedKernel/Domain/Security/UserTypeTest.php
@@ -35,12 +35,4 @@ class UserTypeTest extends TestCase
         $this->assertContains(UserType::CUSTOMER, $all);
         $this->assertContains(UserType::ANONYMOUS, $all);
     }
-
-    public function testConstantValues(): void
-    {
-        $this->assertSame('admin', UserType::ADMIN);
-        $this->assertSame('partner', UserType::PARTNER);
-        $this->assertSame('customer', UserType::CUSTOMER);
-        $this->assertSame('anonymous', UserType::ANONYMOUS);
-    }
 }

--- a/backend/tests/Unit/SharedKernel/Domain/Security/UserTypeTest.php
+++ b/backend/tests/Unit/SharedKernel/Domain/Security/UserTypeTest.php
@@ -14,7 +14,6 @@ class UserTypeTest extends TestCase
         $this->assertTrue(UserType::isValid(UserType::ADMIN));
         $this->assertTrue(UserType::isValid(UserType::PARTNER));
         $this->assertTrue(UserType::isValid(UserType::CUSTOMER));
-        $this->assertTrue(UserType::isValid(UserType::SYSTEM));
         $this->assertTrue(UserType::isValid(UserType::ANONYMOUS));
     }
 
@@ -23,17 +22,17 @@ class UserTypeTest extends TestCase
         $this->assertFalse(UserType::isValid('superadmin'));
         $this->assertFalse(UserType::isValid(''));
         $this->assertFalse(UserType::isValid('ADMIN'));
+        $this->assertFalse(UserType::isValid('system'));
     }
 
     public function testGetAllReturnsAllDefinedTypes(): void
     {
         $all = UserType::getAll();
 
-        $this->assertCount(5, $all);
+        $this->assertCount(4, $all);
         $this->assertContains(UserType::ADMIN, $all);
         $this->assertContains(UserType::PARTNER, $all);
         $this->assertContains(UserType::CUSTOMER, $all);
-        $this->assertContains(UserType::SYSTEM, $all);
         $this->assertContains(UserType::ANONYMOUS, $all);
     }
 
@@ -42,7 +41,6 @@ class UserTypeTest extends TestCase
         $this->assertSame('admin', UserType::ADMIN);
         $this->assertSame('partner', UserType::PARTNER);
         $this->assertSame('customer', UserType::CUSTOMER);
-        $this->assertSame('system', UserType::SYSTEM);
         $this->assertSame('anonymous', UserType::ANONYMOUS);
     }
 }

--- a/backend/tests/Unit/SharedKernel/Infrastructure/CqrsMessageBus/Decorators/SecurityCommandDecoratorTest.php
+++ b/backend/tests/Unit/SharedKernel/Infrastructure/CqrsMessageBus/Decorators/SecurityCommandDecoratorTest.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\SharedKernel\Infrastructure\CqrsMessageBus\Decorators;
+
+use PHPUnit\Framework\TestCase;
+use SharedKernel\Application\CqrsMessageBus\Commands\CommandBusInterface;
+use SharedKernel\Application\CqrsMessageBus\Commands\CommandInterface;
+use SharedKernel\Domain\Security\AuthenticatedUser;
+use SharedKernel\Domain\Security\AuthorizationServiceInterface;
+use SharedKernel\Domain\Security\Exception\SecurityConfigurationException;
+use SharedKernel\Domain\Security\Exception\UnauthenticatedException;
+use SharedKernel\Domain\Security\Exception\UnauthorizedException;
+use SharedKernel\Domain\Security\SecurityConfigInterface;
+use SharedKernel\Domain\Security\SecurityContextInterface;
+use SharedKernel\Infrastructure\CqrsMessageBus\Decorators\SecurityCommandDecorator;
+
+class SecurityCommandDecoratorTest extends TestCase
+{
+    public function testMissingConfigEntryThrowsAndDoesNotDispatch(): void
+    {
+        $command = $this->command();
+        $inner = $this->innerBus();
+        $decorator = new SecurityCommandDecorator(
+            $inner,
+            $this->context(null),
+            $this->authz(false),
+            $this->config([])
+        );
+
+        try {
+            $decorator->dispatch($command);
+            $this->fail('Expected SecurityConfigurationException');
+        } catch (SecurityConfigurationException $e) {
+            $this->assertStringContainsString(get_class($command), $e->getMessage());
+        }
+        $this->assertSame(0, $inner->dispatched);
+    }
+
+    public function testNullPermissionAllowsAnonymousDispatch(): void
+    {
+        $command = $this->command();
+        $inner = $this->innerBus();
+        $decorator = new SecurityCommandDecorator(
+            $inner,
+            $this->context(null),
+            $this->authz(false),
+            $this->config([get_class($command) => null])
+        );
+
+        $decorator->dispatch($command);
+        $this->assertSame(1, $inner->dispatched);
+    }
+
+    public function testPermissionRequiredButNoUserThrowsUnauthenticated(): void
+    {
+        $command = $this->command();
+        $inner = $this->innerBus();
+        $decorator = new SecurityCommandDecorator(
+            $inner,
+            $this->context(null),
+            $this->authz(true),
+            $this->config([get_class($command) => 'foo.do'])
+        );
+
+        $this->expectException(UnauthenticatedException::class);
+        try {
+            $decorator->dispatch($command);
+        } finally {
+            $this->assertSame(0, $inner->dispatched);
+        }
+    }
+
+    public function testUserLacksPermissionThrowsUnauthorized(): void
+    {
+        $command = $this->command();
+        $inner = $this->innerBus();
+        $user = new AuthenticatedUser('1', 'a@example.com', ['viewer']);
+        $decorator = new SecurityCommandDecorator(
+            $inner,
+            $this->context($user),
+            $this->authz(false),
+            $this->config([get_class($command) => 'foo.delete'])
+        );
+
+        try {
+            $decorator->dispatch($command);
+            $this->fail('Expected UnauthorizedException');
+        } catch (UnauthorizedException $e) {
+            $this->assertSame('foo.delete', $e->getRequiredPermission());
+        }
+        $this->assertSame(0, $inner->dispatched);
+    }
+
+    public function testUserWithPermissionDispatches(): void
+    {
+        $command = $this->command();
+        $inner = $this->innerBus();
+        $user = new AuthenticatedUser('1', 'a@example.com', ['admin']);
+        $decorator = new SecurityCommandDecorator(
+            $inner,
+            $this->context($user),
+            $this->authz(true),
+            $this->config([get_class($command) => 'foo.do'])
+        );
+
+        $decorator->dispatch($command);
+
+        $this->assertSame(1, $inner->dispatched);
+        $this->assertSame($command, $inner->lastCommand);
+    }
+
+    public function testCliMisuseFailsClosed(): void
+    {
+        // A bulk-import script that forgets to populate SecurityContext should fail closed,
+        // not silently allow execution. This is the most likely production bug class.
+        $command = $this->command();
+        $inner = $this->innerBus();
+        $decorator = new SecurityCommandDecorator(
+            $inner,
+            $this->context(null),
+            $this->authz(true),
+            $this->config([get_class($command) => 'bulk.import'])
+        );
+
+        $this->expectException(UnauthenticatedException::class);
+        try {
+            $decorator->dispatch($command);
+        } finally {
+            $this->assertSame(0, $inner->dispatched);
+        }
+    }
+
+    private function command(): CommandInterface
+    {
+        return new class implements CommandInterface {
+        };
+    }
+
+    /**
+     * @return CommandBusInterface&object{dispatched: int, lastCommand: ?CommandInterface}
+     */
+    private function innerBus(): CommandBusInterface
+    {
+        return new class implements CommandBusInterface {
+            public int $dispatched = 0;
+            public ?CommandInterface $lastCommand = null;
+
+            public function dispatch(CommandInterface $command): void
+            {
+                $this->dispatched++;
+                $this->lastCommand = $command;
+            }
+        };
+    }
+
+    private function context(?AuthenticatedUser $user): SecurityContextInterface
+    {
+        return new class ($user) implements SecurityContextInterface {
+            private ?AuthenticatedUser $user;
+
+            public function __construct(?AuthenticatedUser $user)
+            {
+                $this->user = $user;
+            }
+
+            public function getCurrentUser(): ?AuthenticatedUser
+            {
+                return $this->user;
+            }
+
+            public function setCurrentUser(AuthenticatedUser $user): void
+            {
+                $this->user = $user;
+            }
+
+            public function hasAuthenticatedUser(): bool
+            {
+                return $this->user !== null;
+            }
+
+            public function clearUser(): void
+            {
+                $this->user = null;
+            }
+        };
+    }
+
+    private function authz(bool $allowed): AuthorizationServiceInterface
+    {
+        return new class ($allowed) implements AuthorizationServiceInterface {
+            private bool $allowed;
+
+            public function __construct(bool $allowed)
+            {
+                $this->allowed = $allowed;
+            }
+
+            public function isAllowed(AuthenticatedUser $user, string $permission): bool
+            {
+                return $this->allowed;
+            }
+        };
+    }
+
+    /**
+     * @param array<class-string, string|null> $commands
+     */
+    private function config(array $commands): SecurityConfigInterface
+    {
+        return new class ($commands) implements SecurityConfigInterface {
+            /** @var array<class-string, string|null> */
+            private array $commands;
+
+            /**
+             * @param array<class-string, string|null> $commands
+             */
+            public function __construct(array $commands)
+            {
+                $this->commands = $commands;
+            }
+
+            public function getCommandPermissions(): array
+            {
+                return $this->commands;
+            }
+
+            public function getQueryPermissions(): array
+            {
+                return [];
+            }
+
+            public function getRolePermissions(): array
+            {
+                return [];
+            }
+        };
+    }
+}

--- a/backend/tests/Unit/SharedKernel/Infrastructure/CqrsMessageBus/Decorators/SecurityQueryDecoratorTest.php
+++ b/backend/tests/Unit/SharedKernel/Infrastructure/CqrsMessageBus/Decorators/SecurityQueryDecoratorTest.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\SharedKernel\Infrastructure\CqrsMessageBus\Decorators;
+
+use PHPUnit\Framework\TestCase;
+use SharedKernel\Application\CqrsMessageBus\Queries\QueryInterface;
+use SharedKernel\Application\CqrsMessageBus\Queries\QueryResponseInterface;
+use SharedKernel\Domain\Security\AuthenticatedUser;
+use SharedKernel\Domain\Security\AuthorizationServiceInterface;
+use SharedKernel\Domain\Security\Exception\SecurityConfigurationException;
+use SharedKernel\Domain\Security\Exception\UnauthenticatedException;
+use SharedKernel\Domain\Security\Exception\UnauthorizedException;
+use SharedKernel\Domain\Security\SecurityConfigInterface;
+use SharedKernel\Domain\Security\SecurityContextInterface;
+use SharedKernel\Infrastructure\CqrsMessageBus\Decorators\SecurityQueryDecorator;
+use Tests\Fixtures\SharedKernel\Security\SpyQueryBus;
+
+class SecurityQueryDecoratorTest extends TestCase
+{
+    public function testMissingConfigEntryThrowsAndDoesNotDispatch(): void
+    {
+        $query = $this->query();
+        $inner = new SpyQueryBus();
+        $decorator = new SecurityQueryDecorator(
+            $inner,
+            $this->context(null),
+            $this->authz(false),
+            $this->config([])
+        );
+
+        try {
+            $decorator->dispatch($query);
+            $this->fail('Expected SecurityConfigurationException');
+        } catch (SecurityConfigurationException $e) {
+            $this->assertStringContainsString(get_class($query), $e->getMessage());
+        }
+        $this->assertSame(0, $inner->dispatched);
+    }
+
+    public function testNullPermissionAllowsAnonymousDispatchAndReturnsResponse(): void
+    {
+        $query = $this->query();
+        $expectedResponse = $this->response();
+        $inner = new SpyQueryBus($expectedResponse);
+        $decorator = new SecurityQueryDecorator(
+            $inner,
+            $this->context(null),
+            $this->authz(false),
+            $this->config([get_class($query) => null])
+        );
+
+        $result = $decorator->dispatch($query);
+        $this->assertSame(1, $inner->dispatched);
+        $this->assertSame($expectedResponse, $result);
+    }
+
+    public function testPermissionRequiredButNoUserThrowsUnauthenticated(): void
+    {
+        $query = $this->query();
+        $inner = new SpyQueryBus();
+        $decorator = new SecurityQueryDecorator(
+            $inner,
+            $this->context(null),
+            $this->authz(true),
+            $this->config([get_class($query) => 'foo.read'])
+        );
+
+        $this->expectException(UnauthenticatedException::class);
+        try {
+            $decorator->dispatch($query);
+        } finally {
+            $this->assertSame(0, $inner->dispatched);
+        }
+    }
+
+    public function testUserLacksPermissionThrowsUnauthorized(): void
+    {
+        $query = $this->query();
+        $inner = new SpyQueryBus();
+        $user = new AuthenticatedUser('1', 'a@example.com', ['viewer']);
+        $decorator = new SecurityQueryDecorator(
+            $inner,
+            $this->context($user),
+            $this->authz(false),
+            $this->config([get_class($query) => 'foo.sensitive'])
+        );
+
+        try {
+            $decorator->dispatch($query);
+            $this->fail('Expected UnauthorizedException');
+        } catch (UnauthorizedException $e) {
+            $this->assertSame('foo.sensitive', $e->getRequiredPermission());
+        }
+        $this->assertSame(0, $inner->dispatched);
+    }
+
+    public function testUserWithPermissionDispatchesAndReturnsResponse(): void
+    {
+        $query = $this->query();
+        $expectedResponse = $this->response();
+        $inner = new SpyQueryBus($expectedResponse);
+        $user = new AuthenticatedUser('1', 'a@example.com', ['admin']);
+        $decorator = new SecurityQueryDecorator(
+            $inner,
+            $this->context($user),
+            $this->authz(true),
+            $this->config([get_class($query) => 'foo.read'])
+        );
+
+        $result = $decorator->dispatch($query);
+
+        $this->assertSame(1, $inner->dispatched);
+        $this->assertSame($query, $inner->lastQuery);
+        $this->assertSame($expectedResponse, $result);
+    }
+
+    public function testCliMisuseFailsClosed(): void
+    {
+        $query = $this->query();
+        $inner = new SpyQueryBus();
+        $decorator = new SecurityQueryDecorator(
+            $inner,
+            $this->context(null),
+            $this->authz(true),
+            $this->config([get_class($query) => 'bulk.read'])
+        );
+
+        $this->expectException(UnauthenticatedException::class);
+        try {
+            $decorator->dispatch($query);
+        } finally {
+            $this->assertSame(0, $inner->dispatched);
+        }
+    }
+
+    private function query(): QueryInterface
+    {
+        return new class implements QueryInterface {
+        };
+    }
+
+    private function response(): QueryResponseInterface
+    {
+        return new class implements QueryResponseInterface {
+        };
+    }
+
+    private function context(?AuthenticatedUser $user): SecurityContextInterface
+    {
+        return new class ($user) implements SecurityContextInterface {
+            private ?AuthenticatedUser $user;
+
+            public function __construct(?AuthenticatedUser $user)
+            {
+                $this->user = $user;
+            }
+
+            public function getCurrentUser(): ?AuthenticatedUser
+            {
+                return $this->user;
+            }
+
+            public function setCurrentUser(AuthenticatedUser $user): void
+            {
+                $this->user = $user;
+            }
+
+            public function hasAuthenticatedUser(): bool
+            {
+                return $this->user !== null;
+            }
+
+            public function clearUser(): void
+            {
+                $this->user = null;
+            }
+        };
+    }
+
+    private function authz(bool $allowed): AuthorizationServiceInterface
+    {
+        return new class ($allowed) implements AuthorizationServiceInterface {
+            private bool $allowed;
+
+            public function __construct(bool $allowed)
+            {
+                $this->allowed = $allowed;
+            }
+
+            public function isAllowed(AuthenticatedUser $user, string $permission): bool
+            {
+                return $this->allowed;
+            }
+        };
+    }
+
+    /**
+     * @param array<class-string, string|null> $queries
+     */
+    private function config(array $queries): SecurityConfigInterface
+    {
+        return new class ($queries) implements SecurityConfigInterface {
+            /** @var array<class-string, string|null> */
+            private array $queries;
+
+            /**
+             * @param array<class-string, string|null> $queries
+             */
+            public function __construct(array $queries)
+            {
+                $this->queries = $queries;
+            }
+
+            public function getCommandPermissions(): array
+            {
+                return [];
+            }
+
+            public function getQueryPermissions(): array
+            {
+                return $this->queries;
+            }
+
+            public function getRolePermissions(): array
+            {
+                return [];
+            }
+        };
+    }
+}

--- a/backend/tests/Unit/SharedKernel/Infrastructure/Security/CompositeSecurityConfigTest.php
+++ b/backend/tests/Unit/SharedKernel/Infrastructure/Security/CompositeSecurityConfigTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\SharedKernel\Infrastructure\Security;
+
+use PHPUnit\Framework\TestCase;
+use SharedKernel\Domain\Security\Exception\SecurityConfigurationException;
+use SharedKernel\Domain\Security\SecurityConfigInterface;
+use SharedKernel\Infrastructure\Security\CompositeSecurityConfig;
+use Tests\Fixtures\SharedKernel\CqrsMessageBus\SecondTestCommand;
+use Tests\Fixtures\SharedKernel\CqrsMessageBus\SecondTestQuery;
+use Tests\Fixtures\SharedKernel\CqrsMessageBus\TestCommand;
+use Tests\Fixtures\SharedKernel\CqrsMessageBus\TestQuery;
+use Tests\Fixtures\SharedKernel\Security\CountingSecurityConfig;
+
+class CompositeSecurityConfigTest extends TestCase
+{
+    public function testEmptyListProducesEmptyMaps(): void
+    {
+        $composite = new CompositeSecurityConfig([]);
+
+        $this->assertSame([], $composite->getCommandPermissions());
+        $this->assertSame([], $composite->getQueryPermissions());
+        $this->assertSame([], $composite->getRolePermissions());
+    }
+
+    public function testSingleConfigPassesThrough(): void
+    {
+        $config = $this->configWith(
+            [TestCommand::class => 'a.do'],
+            [TestQuery::class => 'a.read'],
+            ['viewer' => ['a.read']]
+        );
+        $composite = new CompositeSecurityConfig([$config]);
+
+        $this->assertSame([TestCommand::class => 'a.do'], $composite->getCommandPermissions());
+        $this->assertSame([TestQuery::class => 'a.read'], $composite->getQueryPermissions());
+        $this->assertSame(['viewer' => ['a.read']], $composite->getRolePermissions());
+    }
+
+    public function testDisjointConfigsAreMerged(): void
+    {
+        $a = $this->configWith(
+            [TestCommand::class => 'a.do'],
+            [TestQuery::class => 'a.read'],
+            ['viewer' => ['user.view']]
+        );
+        $b = $this->configWith(
+            [SecondTestCommand::class => 'b.do'],
+            [SecondTestQuery::class => 'b.read'],
+            ['editor' => ['user.create']]
+        );
+        $composite = new CompositeSecurityConfig([$a, $b]);
+
+        $this->assertSame(
+            [TestCommand::class => 'a.do', SecondTestCommand::class => 'b.do'],
+            $composite->getCommandPermissions()
+        );
+        $this->assertSame(
+            [TestQuery::class => 'a.read', SecondTestQuery::class => 'b.read'],
+            $composite->getQueryPermissions()
+        );
+        $this->assertSame(
+            ['viewer' => ['user.view'], 'editor' => ['user.create']],
+            $composite->getRolePermissions()
+        );
+    }
+
+    public function testNullPermissionEntryIsPreservedThroughMerge(): void
+    {
+        $a = $this->configWith([TestCommand::class => null], [], []);
+        $b = $this->configWith([SecondTestCommand::class => 'other.do'], [], []);
+        $composite = new CompositeSecurityConfig([$a, $b]);
+
+        $merged = $composite->getCommandPermissions();
+        $this->assertArrayHasKey(TestCommand::class, $merged);
+        $this->assertNull($merged[TestCommand::class]);
+        $this->assertSame('other.do', $merged[SecondTestCommand::class]);
+    }
+
+    public function testDuplicateCommandKeyThrows(): void
+    {
+        $a = $this->configWith([TestCommand::class => 'a.do'], [], []);
+        $b = $this->configWith([TestCommand::class => 'b.do'], [], []);
+        $composite = new CompositeSecurityConfig([$a, $b]);
+
+        $this->expectException(SecurityConfigurationException::class);
+        $this->expectExceptionMessageMatches('/Duplicate.*TestCommand/');
+        $composite->getCommandPermissions();
+    }
+
+    public function testDuplicateQueryKeyThrows(): void
+    {
+        $a = $this->configWith([], [TestQuery::class => 'a.read'], []);
+        $b = $this->configWith([], [TestQuery::class => 'b.read'], []);
+        $composite = new CompositeSecurityConfig([$a, $b]);
+
+        $this->expectException(SecurityConfigurationException::class);
+        $this->expectExceptionMessageMatches('/Duplicate.*TestQuery/');
+        $composite->getQueryPermissions();
+    }
+
+    public function testRolePermissionsUnionAndDeduplicate(): void
+    {
+        $a = $this->configWith([], [], ['admin' => ['user.create', 'user.view']]);
+        $b = $this->configWith([], [], ['admin' => ['user.view', 'user.delete']]);
+        $composite = new CompositeSecurityConfig([$a, $b]);
+
+        $roles = $composite->getRolePermissions();
+
+        $this->assertArrayHasKey('admin', $roles);
+        sort($roles['admin']);
+        $this->assertSame(['user.create', 'user.delete', 'user.view'], $roles['admin']);
+    }
+
+    public function testResultsAreCachedAcrossCalls(): void
+    {
+        $config = new CountingSecurityConfig();
+        $composite = new CompositeSecurityConfig([$config]);
+
+        $composite->getCommandPermissions();
+        $composite->getCommandPermissions();
+        $composite->getQueryPermissions();
+        $composite->getQueryPermissions();
+        $composite->getRolePermissions();
+        $composite->getRolePermissions();
+
+        $this->assertSame(1, $config->commandCalls);
+        $this->assertSame(1, $config->queryCalls);
+        $this->assertSame(1, $config->roleCalls);
+    }
+
+    /**
+     * @param array<class-string, string|null> $commands
+     * @param array<class-string, string|null> $queries
+     * @param array<string, array<string>> $roles
+     */
+    private function configWith(array $commands, array $queries, array $roles): SecurityConfigInterface
+    {
+        return new class ($commands, $queries, $roles) implements SecurityConfigInterface {
+            /** @var array<class-string, string|null> */
+            private array $commands;
+            /** @var array<class-string, string|null> */
+            private array $queries;
+            /** @var array<string, array<string>> */
+            private array $roles;
+
+            /**
+             * @param array<class-string, string|null> $commands
+             * @param array<class-string, string|null> $queries
+             * @param array<string, array<string>> $roles
+             */
+            public function __construct(array $commands, array $queries, array $roles)
+            {
+                $this->commands = $commands;
+                $this->queries = $queries;
+                $this->roles = $roles;
+            }
+
+            public function getCommandPermissions(): array
+            {
+                return $this->commands;
+            }
+
+            public function getQueryPermissions(): array
+            {
+                return $this->queries;
+            }
+
+            public function getRolePermissions(): array
+            {
+                return $this->roles;
+            }
+        };
+    }
+}

--- a/backend/tests/Unit/SharedKernel/Infrastructure/Security/ConfigAuthorizationServiceTest.php
+++ b/backend/tests/Unit/SharedKernel/Infrastructure/Security/ConfigAuthorizationServiceTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\SharedKernel\Infrastructure\Security;
+
+use PHPUnit\Framework\TestCase;
+use SharedKernel\Domain\Security\AuthenticatedUser;
+use SharedKernel\Domain\Security\SecurityConfigInterface;
+use SharedKernel\Infrastructure\Security\ConfigAuthorizationService;
+
+class ConfigAuthorizationServiceTest extends TestCase
+{
+    public function testUserWithNoRolesIsDenied(): void
+    {
+        $service = new ConfigAuthorizationService($this->configWithRoles([]));
+        $user = new AuthenticatedUser('1', 'a@example.com', []);
+
+        $this->assertFalse($service->isAllowed($user, 'user.create'));
+    }
+
+    public function testRoleGrantingExactPermissionAllows(): void
+    {
+        $service = new ConfigAuthorizationService($this->configWithRoles([
+            'editor' => ['user.create', 'user.view'],
+        ]));
+        $user = new AuthenticatedUser('1', 'a@example.com', ['editor']);
+
+        $this->assertTrue($service->isAllowed($user, 'user.create'));
+        $this->assertTrue($service->isAllowed($user, 'user.view'));
+        $this->assertFalse($service->isAllowed($user, 'user.delete'));
+    }
+
+    public function testWildcardRoleAllowsAnyPermission(): void
+    {
+        $service = new ConfigAuthorizationService($this->configWithRoles([
+            'super_admin' => ['*'],
+        ]));
+        $user = new AuthenticatedUser('1', 'a@example.com', ['super_admin']);
+
+        $this->assertTrue($service->isAllowed($user, 'user.create'));
+        $this->assertTrue($service->isAllowed($user, 'anything.you.want'));
+    }
+
+    public function testMultipleRolesAggregatePermissions(): void
+    {
+        $service = new ConfigAuthorizationService($this->configWithRoles([
+            'viewer' => ['user.view'],
+            'editor' => ['user.create'],
+        ]));
+        $user = new AuthenticatedUser('1', 'a@example.com', ['viewer', 'editor']);
+
+        $this->assertTrue($service->isAllowed($user, 'user.view'));
+        $this->assertTrue($service->isAllowed($user, 'user.create'));
+        $this->assertFalse($service->isAllowed($user, 'user.delete'));
+    }
+
+    public function testUnknownRoleIsSilentlyIgnored(): void
+    {
+        $service = new ConfigAuthorizationService($this->configWithRoles([
+            'viewer' => ['user.view'],
+        ]));
+        $user = new AuthenticatedUser('1', 'a@example.com', ['phantom_role']);
+
+        $this->assertFalse($service->isAllowed($user, 'user.view'));
+    }
+
+    public function testWildcardOnOneRoleStillAllowsWhenOtherRolesPresent(): void
+    {
+        $service = new ConfigAuthorizationService($this->configWithRoles([
+            'viewer' => ['user.view'],
+            'system' => ['*'],
+        ]));
+        $user = new AuthenticatedUser('1', 'a@example.com', ['viewer', 'system']);
+
+        $this->assertTrue($service->isAllowed($user, 'something.exotic'));
+    }
+
+    /**
+     * @param array<string, array<string>> $roles
+     */
+    private function configWithRoles(array $roles): SecurityConfigInterface
+    {
+        return new class ($roles) implements SecurityConfigInterface {
+            /** @var array<string, array<string>> */
+            private array $roles;
+
+            /**
+             * @param array<string, array<string>> $roles
+             */
+            public function __construct(array $roles)
+            {
+                $this->roles = $roles;
+            }
+
+            public function getCommandPermissions(): array
+            {
+                return [];
+            }
+
+            public function getQueryPermissions(): array
+            {
+                return [];
+            }
+
+            public function getRolePermissions(): array
+            {
+                return $this->roles;
+            }
+        };
+    }
+}

--- a/backend/tests/Unit/SharedKernel/Infrastructure/Security/SecurityConfigFactoryTest.php
+++ b/backend/tests/Unit/SharedKernel/Infrastructure/Security/SecurityConfigFactoryTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\SharedKernel\Infrastructure\Security;
+
+use PHPUnit\Framework\TestCase;
+use SharedKernel\Domain\Security\SecurityConfigInterface;
+use SharedKernel\Infrastructure\Security\CompositeSecurityConfig;
+use SharedKernel\Infrastructure\Security\SecurityConfigFactory;
+use SharedKernel\Domain\Security\SecurityConfigRegistryInterface;
+use Tests\Fixtures\SharedKernel\CqrsMessageBus\SecondTestCommand;
+use Tests\Fixtures\SharedKernel\CqrsMessageBus\TestCommand;
+use Tests\Fixtures\SharedKernel\CqrsMessageBus\ThirdTestCommand;
+
+class SecurityConfigFactoryTest extends TestCase
+{
+    public function testInvokeReturnsCompositeWithNoRegistries(): void
+    {
+        $factory = new SecurityConfigFactory([]);
+        $result = $factory();
+
+        $this->assertInstanceOf(CompositeSecurityConfig::class, $result);
+        $this->assertSame([], $result->getCommandPermissions());
+    }
+
+    public function testInvokeAggregatesAllConfigsFromAllRegistries(): void
+    {
+        $configA = $this->config([TestCommand::class => 'a.do'], []);
+        $configB = $this->config([SecondTestCommand::class => 'b.do'], []);
+        $configC = $this->config([ThirdTestCommand::class => 'c.do'], ['admin' => ['c.do']]);
+
+        $registry1 = $this->registry([$configA, $configB]);
+        $registry2 = $this->registry([$configC]);
+
+        $factory = new SecurityConfigFactory([$registry1, $registry2]);
+        $result = $factory();
+
+        $this->assertSame(
+            [
+                TestCommand::class => 'a.do',
+                SecondTestCommand::class => 'b.do',
+                ThirdTestCommand::class => 'c.do',
+            ],
+            $result->getCommandPermissions()
+        );
+        $this->assertSame(['admin' => ['c.do']], $result->getRolePermissions());
+    }
+
+    /**
+     * @param array<class-string, string|null> $commands
+     * @param array<string, array<string>> $roles
+     */
+    private function config(array $commands, array $roles): SecurityConfigInterface
+    {
+        return new class ($commands, $roles) implements SecurityConfigInterface {
+            /** @var array<class-string, string|null> */
+            private array $commands;
+            /** @var array<string, array<string>> */
+            private array $roles;
+
+            /**
+             * @param array<class-string, string|null> $commands
+             * @param array<string, array<string>> $roles
+             */
+            public function __construct(array $commands, array $roles)
+            {
+                $this->commands = $commands;
+                $this->roles = $roles;
+            }
+
+            public function getCommandPermissions(): array
+            {
+                return $this->commands;
+            }
+
+            public function getQueryPermissions(): array
+            {
+                return [];
+            }
+
+            public function getRolePermissions(): array
+            {
+                return $this->roles;
+            }
+        };
+    }
+
+    /**
+     * @param SecurityConfigInterface[] $configs
+     */
+    private function registry(array $configs): SecurityConfigRegistryInterface
+    {
+        return new class ($configs) implements SecurityConfigRegistryInterface {
+            /** @var SecurityConfigInterface[] */
+            private array $configs;
+
+            /**
+             * @param SecurityConfigInterface[] $configs
+             */
+            public function __construct(array $configs)
+            {
+                $this->configs = $configs;
+            }
+
+            public function getSecurityConfigs(): array
+            {
+                return $this->configs;
+            }
+        };
+    }
+}

--- a/fuelphp/fuel/app/config/di.php
+++ b/fuelphp/fuel/app/config/di.php
@@ -1,10 +1,13 @@
 <?php
 
+use Audience\Admin\Infrastructure\Security\AdminSecurityConfigRegistry;
+use Audience\Partner\Infrastructure\Security\PartnerSecurityConfigRegistry;
 use DI\ContainerBuilder;
 use Fuel\Core\Fuel;
 use Infrastructure\EventSystem\FuelPhpOutboxRepository;
 use Infrastructure\EventSystem\FuelPhpScheduledEventRepository;
 use Infrastructure\Http\FuelPhpRequestContext;
+use Infrastructure\Security\FuelPhpAuthUserResolver;
 use Infrastructure\Security\FuelPhpSecurityContext;
 use Psr\Container\ContainerInterface;
 use SharedKernel\Application\CqrsMessageBus\Commands\CommandBusInterface;
@@ -22,7 +25,10 @@ use SharedKernel\Domain\EventSystem\OutboxEventProcessorInterface;
 use SharedKernel\Domain\EventSystem\ScheduledEventProcessorInterface;
 use SharedKernel\Domain\Logger\LoggerInterface;
 use SharedKernel\Domain\Redis\RedisClientInterface;
+use SharedKernel\Domain\Security\AuthorizationServiceInterface;
+use SharedKernel\Domain\Security\SecurityConfigInterface;
 use SharedKernel\Domain\Security\SecurityContextInterface;
+use SharedKernel\Domain\Security\UserResolverInterface;
 use SharedKernel\Domain\Storage\StorageInterface;
 use SharedKernel\Domain\Throttle\ThrottleFactoryInterface;
 use SharedKernel\Infrastructure\Cache\CacheFactory;
@@ -32,7 +38,11 @@ use SharedKernel\Infrastructure\CqrsMessageBus\Decorators\CommandThrottleDecorat
 use SharedKernel\Infrastructure\CqrsMessageBus\Decorators\CommandTransactionDecorator;
 use SharedKernel\Infrastructure\CqrsMessageBus\Decorators\QueryLoggerDecorator;
 use SharedKernel\Infrastructure\CqrsMessageBus\Decorators\QueryThrottleDecorator;
+use SharedKernel\Infrastructure\CqrsMessageBus\Decorators\SecurityCommandDecorator;
+use SharedKernel\Infrastructure\CqrsMessageBus\Decorators\SecurityQueryDecorator;
 use SharedKernel\Infrastructure\CqrsMessageBus\QueryBusFactory;
+use SharedKernel\Infrastructure\Security\ConfigAuthorizationService;
+use SharedKernel\Infrastructure\Security\SecurityConfigFactory;
 use SharedKernel\Infrastructure\EventSystem\DomainEventCollector;
 use SharedKernel\Infrastructure\EventSystem\EventFactoryFactory;
 use SharedKernel\Infrastructure\EventSystem\ListenerProviderFactory;
@@ -71,6 +81,20 @@ $containerBuilder->addDefinitions(array_merge([
     // Security & Request Context
     SecurityContextInterface::class => DI\autowire(FuelPhpSecurityContext::class),
     RequestContextInterface::class => DI\autowire(FuelPhpRequestContext::class),
+    UserResolverInterface::class => DI\autowire(FuelPhpAuthUserResolver::class),
+
+    // Security Config — composed from SharedKernel + per-audience registries.
+    // Bounded contexts (Crm, Marketing) own only domain. Audiences (Admin, Partner, Customer)
+    // own their commands, queries, and roles. Add new audience registries here.
+    SecurityConfigInterface::class => DI\factory(function (ContainerInterface $c) {
+        $factory = new SecurityConfigFactory([
+            $c->get(AdminSecurityConfigRegistry::class),
+            $c->get(PartnerSecurityConfigRegistry::class),
+        ]);
+        return $factory();
+    }),
+    // Depends on SecurityConfigInterface (bound via factory above).
+    AuthorizationServiceInterface::class => DI\autowire(ConfigAuthorizationService::class),
 
     // Throttle
     ThrottleFactoryInterface::class => DI\factory(ThrottleDriverFactory::class),
@@ -79,7 +103,7 @@ $containerBuilder->addDefinitions(array_merge([
     }),
 
     // CQRS Message Bus
-    // Decorator chain (outermost → innermost): Throttle → Logger → Transaction → Handler
+    // Decorator chain (outermost → innermost): Throttle → Security → Logger → Transaction → Handler
     CommandBusInterface::class => DI\factory(function (ContainerInterface $c) {
         $bus = (new CommandBusFactory($c, [
             // Add bounded-context registries here:
@@ -93,6 +117,12 @@ $containerBuilder->addDefinitions(array_merge([
             $c->get(OutboxEventProcessorInterface::class)
         );
         $bus = new CommandLoggerDecorator($bus, $c->get(LoggerInterface::class));
+        $bus = new SecurityCommandDecorator(
+            $bus,
+            $c->get(SecurityContextInterface::class),
+            $c->get(AuthorizationServiceInterface::class),
+            $c->get(SecurityConfigInterface::class)
+        );
         return new CommandThrottleDecorator(
             $bus,
             $c->get(ThrottleFactoryInterface::class),
@@ -103,6 +133,7 @@ $containerBuilder->addDefinitions(array_merge([
             $c->get(LoggerInterface::class)
         );
     }),
+    // Decorator chain (outermost → innermost): Throttle → Security → Logger → Handler
     QueryBusInterface::class => DI\factory(function (ContainerInterface $c) {
         $bus = (new QueryBusFactory($c, [
             // Add bounded-context registries here:
@@ -110,6 +141,12 @@ $containerBuilder->addDefinitions(array_merge([
             // new MarketingQueryHandlerRegistry(),
         ]))();
         $bus = new QueryLoggerDecorator($bus, $c->get(LoggerInterface::class));
+        $bus = new SecurityQueryDecorator(
+            $bus,
+            $c->get(SecurityContextInterface::class),
+            $c->get(AuthorizationServiceInterface::class),
+            $c->get(SecurityConfigInterface::class)
+        );
         return new QueryThrottleDecorator(
             $bus,
             $c->get(ThrottleFactoryInterface::class),

--- a/fuelphp/fuel/app/modules/partner/classes/controller/abstract.php
+++ b/fuelphp/fuel/app/modules/partner/classes/controller/abstract.php
@@ -2,10 +2,18 @@
 
 namespace Partner;
 
+use Container;
 use Fuel\Core\Controller;
+use Fuel\Core\Package;
 use HttpTooManyRequestsException;
 use Infrastructure\Throttle\HttpThrottleTrait;
+use SharedKernel\Domain\Security\SecurityContextInterface;
+use SharedKernel\Domain\Security\UserResolverInterface;
 
+// Partner login flow must call \Auth::instance()->login() (SimpleAuth driver) for the
+// resolver to produce a non-null user. Roles come from simpleauth.groups[<id>].roles.
+// Until login lands, resolve() returns null and any non-public command/query will
+// correctly fail closed with UnauthenticatedException.
 abstract class Controller_Abstract extends Controller
 {
     use HttpThrottleTrait;
@@ -16,6 +24,14 @@ abstract class Controller_Abstract extends Controller
     public function before()
     {
         $this->throttleBeforeRequest();
+        Package::load('auth');
+
+        $resolver = Container::resolve(UserResolverInterface::class);
+        $context = Container::resolve(SecurityContextInterface::class);
+        $user = $resolver->resolve();
+        if ($user !== null) {
+            $context->setCurrentUser($user);
+        }
 
         parent::before();
     }

--- a/fuelphp/fuel/packages/infrastructure/classes/Security/FuelPhpAuthUserResolver.php
+++ b/fuelphp/fuel/packages/infrastructure/classes/Security/FuelPhpAuthUserResolver.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Infrastructure\Security;
+
+use Auth;
+use SharedKernel\Domain\Security\AuthenticatedUser;
+use SharedKernel\Domain\Security\UserResolverInterface;
+use SharedKernel\Domain\Security\UserType;
+
+// Reads the currently logged-in user from FuelPHP Auth (SimpleAuth driver).
+// Roles are the string names declared in `simpleauth.groups[<id>].roles` config —
+// these are the same strings that SecurityConfigInterface::getRolePermissions() keys on.
+final class FuelPhpAuthUserResolver implements UserResolverInterface
+{
+    public function resolve(): ?AuthenticatedUser
+    {
+        if (!Auth::check()) {
+            return null;
+        }
+
+        $instance = Auth::instance();
+        if ($instance === false) {
+            return null;
+        }
+
+        $userId = $instance->get_user_id();
+        if (!is_array($userId) || !isset($userId[1])) {
+            return null;
+        }
+
+        $email = $instance->get_email();
+        $roles = Auth::group()->get_roles();
+        if (!is_array($roles)) {
+            $roles = [];
+        }
+
+        return new AuthenticatedUser(
+            (string) $userId[1],
+            is_string($email) ? $email : '',
+            array_values(array_filter($roles, 'is_string')),
+            UserType::PARTNER
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `SharedKernel` security module providing authentication context + RBAC authorization for CQRS commands and queries via two new bus decorators
- Introduces audience-based code organization (`backend/src/Audience/Admin/`, `backend/src/Audience/Partner/`) that owns commands, queries, and roles, distinct from bounded contexts (`Crm/`, `Marketing/`) which own only domain code
- Wires FuelPHP `\Auth` (SimpleAuth) as the partner-portal user resolver behind a framework-agnostic `UserResolverInterface`
- Captures all design decisions in [ADR-008](backend/docs/adr/008-security-module.md)

## Key design rules

1. Commands and queries declare a **permission only**, never a role list. Role→permission mapping lives in audience security configs. Prevents role explosion.
2. `null` permission = explicit public; missing entry = `SecurityConfigurationException` (fail closed).
3. Audiences own commands, queries, and roles; bounded contexts own only domain.
4. Permissions are audience-scoped (`admin.*`, `partner.*`) — same conceptual operation across audiences = separate command classes.
5. Decorator chain order: `Throttle → Security → Logger → Transaction → Handler`.
6. Authentication is per-driver behind `UserResolverInterface`; login flow is per-framework, not abstracted.

## Out of scope (deliberately deferred)

- Per-instance policies (contextual checks like "edit only your org's invoices")
- Row-level scoping (handled in query handlers, not a generic decorator)
- Field masking / sensitive-field redaction (presentation concern)
- Audit subsystem (existing `*LoggerDecorator` covers it)
- Session/token refresh management (framework concern)
- Cognito/Laravel resolvers (added when those modules land)

See ADR-008 §"Out of Scope" and §"Deferred Decisions" for full rationale.

## Test plan

- [x] Unit tests pass (`make test-unit`) — 265 tests, 539 assertions
- [x] Lint passes (`make lint`) — PHPCS clean
- [x] Static analysis passes (`make phpstan`) — no errors
- [x] Smoke test: `https://partner.php-ddd.test/` returns HTTP 200 — DI container builds cleanly under real FuelPHP runtime
- [ ] Manual verification deferred until partner login flow lands and writes user state via `\Auth::instance()->login()` (resolver currently returns null when no user is logged in, which is the correct fail-closed behavior)
- [ ] Admin and Customer audience resolvers/wiring deferred to future PRs

## Notable changes outside the security module

- `Makefile`: `composer-autoload` target now also dumps `backend`'s autoload (was previously only `fuelphp` and `laravel`)
- `backend/composer.json`: registered `Audience\\` PSR-4 namespace
- `CLAUDE.md`: updated directory structure section to distinguish bounded contexts from audience modules
- `ADR-007`: removed `UserType::SYSTEM` references (background event workers route through their own pipeline and never hit the throttle decorator, so no system-tier exemption is needed)