### PR TITLE
fix: fall back to in-memory async repository in DEV without SQS_ASYNC_EVENTS_QUEUE_URL

### DIFF
--- a/backend/src/SharedKernel/Infrastructure/EventSystem/SqsAsyncEventProcessorFactory.php
+++ b/backend/src/SharedKernel/Infrastructure/EventSystem/SqsAsyncEventProcessorFactory.php
@@ -58,15 +58,17 @@ final class SqsAsyncEventProcessorFactory
 
     private function createRepository(): AsyncRepositoryInterface
     {
-        // Test: In-memory repository (dispatches synchronously)
-        if ($this->environment->isTest()) {
+        // Test, or Development without an SQS endpoint configured: in-memory (synchronous) dispatch.
+        // The DEV fallback lets contributors run the app locally without standing up ElasticMQ —
+        // async events are dispatched synchronously instead of being queued.
+        if ($this->environment->isTest() || ($this->environment->isDevelopment() && $this->queueUrl === '')) {
             return new InMemoryAsyncRepository(
                 $this->listenerProvider,
                 $this->logger
             );
         }
 
-        // Production/Staging/Development: SQS-based repository
+        // Production/Staging/Development (with SQS configured): SQS-based repository
         $config = [
             'region' => $this->region,
             'version' => '2012-11-05',

--- a/backend/tests/Unit/SharedKernel/Infrastructure/EventSystem/SqsAsyncEventProcessorFactoryTest.php
+++ b/backend/tests/Unit/SharedKernel/Infrastructure/EventSystem/SqsAsyncEventProcessorFactoryTest.php
@@ -10,8 +10,9 @@ use SharedKernel\Domain\EventSystem\AsyncEventProcessorInterface;
 use SharedKernel\Domain\EventSystem\EventFactoryInterface;
 use SharedKernel\Domain\EventSystem\ListenerProviderInterface;
 use SharedKernel\Domain\Logger\LoggerInterface;
-use SharedKernel\Infrastructure\EventSystem\SqsAsyncEventProcessorFactory;
 use ReflectionMethod;
+use RuntimeException;
+use SharedKernel\Infrastructure\EventSystem\SqsAsyncEventProcessorFactory;
 
 class SqsAsyncEventProcessorFactoryTest extends TestCase
 {
@@ -29,6 +30,37 @@ class SqsAsyncEventProcessorFactoryTest extends TestCase
         $processor = $factory();
 
         $this->assertInstanceOf(AsyncEventProcessorInterface::class, $processor);
+    }
+
+    public function testCreatesInMemoryProcessorForDevelopmentWhenQueueUrlIsEmpty(): void
+    {
+        $factory = new SqsAsyncEventProcessorFactory(
+            new Environment('development'),
+            $this->createMock(EventFactoryInterface::class),
+            $this->createMock(ListenerProviderInterface::class),
+            $this->createMock(LoggerInterface::class),
+            '',
+            ''
+        );
+
+        $processor = $factory();
+
+        $this->assertInstanceOf(AsyncEventProcessorInterface::class, $processor);
+    }
+
+    public function testThrowsForDevelopmentWhenQueueUrlIsMalformed(): void
+    {
+        $factory = new SqsAsyncEventProcessorFactory(
+            new Environment('development'),
+            $this->createMock(EventFactoryInterface::class),
+            $this->createMock(ListenerProviderInterface::class),
+            $this->createMock(LoggerInterface::class),
+            'not-a-url',
+            'us-east-1'
+        );
+
+        $this->expectException(RuntimeException::class);
+        $factory();
     }
 
     /**


### PR DESCRIPTION
## Problem

`CommandThrottleDecorator` and `QueryThrottleDecorator` declare `AsyncEventProcessorInterface` as a constructor dependency, so PHP-DI resolves it eagerly when the bus is built. In DEV with an empty `SQS_ASYNC_EVENTS_QUEUE_URL` (which is the dev default, since no ElasticMQ service is wired in `docker-compose.yml`), `SqsAsyncEventProcessorFactory::createRepository()` throws `RuntimeException` at boot.

The issue had never surfaced because no existing controller dispatched a command/query through the bus. The first feature that hits the bus on a public path (catalog home page, separate PR) makes it a blocker.

## Solution

Mirror the existing TEST-env branch: return `InMemoryAsyncRepository` (synchronous dispatch) when DEV runs without a queue URL. Malformed-but-non-empty URLs still throw `RuntimeException` so misconfiguration stays loud.

```php
if ($this->environment->isTest() || ($this->environment->isDevelopment() && $this->queueUrl === '')) {
    return new InMemoryAsyncRepository(...);
}
```

## Test plan

- [x] new unit test: DEV + empty URL -> in-memory processor
- [x] new unit test: DEV + malformed URL -> `RuntimeException`
- [x] existing test (TEST env) still passes
- [x] `make test-unit` and `make lint` green