### PR TITLE
feat: shop home page with Catalog BC and Audience/Site BFF

### DIFF
--- a/backend/composer.json
+++ b/backend/composer.json
@@ -6,6 +6,7 @@
   "autoload": {
     "psr-4": {
       "Audience\\": "src/Audience/",
+      "Catalog\\": "src/Catalog/",
       "Crm\\": "src/Crm/",
       "Marketing\\": "src/Marketing/",
       "SharedKernel\\": "src/SharedKernel/"

--- a/backend/src/Audience/Site/Application/Query/SearchCatalogProducts/SearchCatalogProductsQuery.php
+++ b/backend/src/Audience/Site/Application/Query/SearchCatalogProducts/SearchCatalogProductsQuery.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Audience\Site\Application\Query\SearchCatalogProducts;
+
+use Catalog\Application\ReadModel\SearchFilters;
+use SharedKernel\Application\CqrsMessageBus\Queries\QueryInterface;
+
+/**
+ * Customer-facing query: paginate products for the public catalog.
+ *
+ * Audience boundary: this is the *public* contract a non-authenticated visitor is allowed
+ * to issue. It delegates internally to `Catalog\Application\Service\CatalogReadService` for
+ * the actual read; the audience layer owns the permission, the HTTP-input parsing, and any
+ * audience-specific shaping.
+ *
+ * @implements QueryInterface<SearchCatalogProductsResponse>
+ */
+final class SearchCatalogProductsQuery implements QueryInterface
+{
+    public const DEFAULT_PER_PAGE = 12;
+
+    private SearchFilters $filters;
+    private int $page;
+    private int $perPage;
+
+    public function __construct(SearchFilters $filters, int $page = 1, int $perPage = self::DEFAULT_PER_PAGE)
+    {
+        $this->filters = $filters;
+        $this->page = $page < 1 ? 1 : $page;
+        $this->perPage = $perPage < 1 ? self::DEFAULT_PER_PAGE : $perPage;
+    }
+
+    /**
+     * Builds the query from an untrusted HTTP query-string array (e.g. $_GET).
+     *
+     * @param array<string, mixed> $raw
+     */
+    public static function fromHttpInput(array $raw): self
+    {
+        $filters = SearchFilters::fromHttpInput($raw);
+        $page = $raw['page'] ?? null;
+        if (is_int($page)) {
+            $intPage = $page;
+        } elseif (is_string($page) && preg_match('/^\d+$/', $page) === 1) {
+            $intPage = (int) $page;
+        } else {
+            $intPage = 1;
+        }
+        return new self($filters, $intPage);
+    }
+
+    public function getFilters(): SearchFilters
+    {
+        return $this->filters;
+    }
+
+    public function getPage(): int
+    {
+        return $this->page;
+    }
+
+    public function getPerPage(): int
+    {
+        return $this->perPage;
+    }
+}

--- a/backend/src/Audience/Site/Application/Query/SearchCatalogProducts/SearchCatalogProductsQueryHandler.php
+++ b/backend/src/Audience/Site/Application/Query/SearchCatalogProducts/SearchCatalogProductsQueryHandler.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Audience\Site\Application\Query\SearchCatalogProducts;
+
+use Catalog\Application\Service\CatalogReadService;
+use SharedKernel\Application\CqrsMessageBus\Queries\QueryHandlerInterface;
+
+final class SearchCatalogProductsQueryHandler implements QueryHandlerInterface
+{
+    private CatalogReadService $catalog;
+
+    public function __construct(CatalogReadService $catalog)
+    {
+        $this->catalog = $catalog;
+    }
+
+    public function __invoke(SearchCatalogProductsQuery $query): SearchCatalogProductsResponse
+    {
+        $result = $this->catalog->searchProducts(
+            $query->getFilters(),
+            $query->getPage(),
+            $query->getPerPage()
+        );
+        return new SearchCatalogProductsResponse($result);
+    }
+}

--- a/backend/src/Audience/Site/Application/Query/SearchCatalogProducts/SearchCatalogProductsResponse.php
+++ b/backend/src/Audience/Site/Application/Query/SearchCatalogProducts/SearchCatalogProductsResponse.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Audience\Site\Application\Query\SearchCatalogProducts;
+
+use Catalog\Application\ReadModel\ProductSearchResult;
+use SharedKernel\Application\CqrsMessageBus\Queries\QueryResponseInterface;
+
+/**
+ * Customer-audience response for SearchCatalogProducts.
+ *
+ * Wraps the Catalog read model so the audience contract stays stable when the BC evolves,
+ * and so audience-specific metadata (cache hints, pagination flags, etc.) can be added
+ * here without leaking into Catalog.
+ */
+final class SearchCatalogProductsResponse implements QueryResponseInterface
+{
+    private ProductSearchResult $result;
+
+    public function __construct(ProductSearchResult $result)
+    {
+        $this->result = $result;
+    }
+
+    public function getResult(): ProductSearchResult
+    {
+        return $this->result;
+    }
+}

--- a/backend/src/Audience/Site/Application/Query/ViewCatalogHomePage/ViewCatalogHomePageQuery.php
+++ b/backend/src/Audience/Site/Application/Query/ViewCatalogHomePage/ViewCatalogHomePageQuery.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Audience\Site\Application\Query\ViewCatalogHomePage;
+
+use Catalog\Application\ReadModel\SearchFilters;
+use SharedKernel\Application\CqrsMessageBus\Queries\QueryInterface;
+
+/**
+ * Customer-facing composite query: everything a visitor needs to render the catalog landing page.
+ *
+ * One dispatch = one decorator chain (throttle/security/log). Internally delegates to the
+ * `Catalog` BC for products and facets. This is the canonical pattern for read-side composition:
+ * the audience layer owns the page-shaped query; the BC owns the small, reusable building blocks.
+ *
+ * @implements QueryInterface<ViewCatalogHomePageResponse>
+ */
+final class ViewCatalogHomePageQuery implements QueryInterface
+{
+    public const DEFAULT_PER_PAGE = 12;
+
+    private SearchFilters $filters;
+    private int $page;
+    private int $perPage;
+
+    public function __construct(SearchFilters $filters, int $page = 1, int $perPage = self::DEFAULT_PER_PAGE)
+    {
+        $this->filters = $filters;
+        $this->page = $page < 1 ? 1 : $page;
+        $this->perPage = $perPage < 1 ? self::DEFAULT_PER_PAGE : $perPage;
+    }
+
+    /**
+     * @param array<string, mixed> $raw
+     */
+    public static function fromHttpInput(array $raw): self
+    {
+        $filters = SearchFilters::fromHttpInput($raw);
+        $page = $raw['page'] ?? null;
+        if (is_int($page)) {
+            $intPage = $page;
+        } elseif (is_string($page) && preg_match('/^\d+$/', $page) === 1) {
+            $intPage = (int) $page;
+        } else {
+            $intPage = 1;
+        }
+        return new self($filters, $intPage);
+    }
+
+    public function getFilters(): SearchFilters
+    {
+        return $this->filters;
+    }
+
+    public function getPage(): int
+    {
+        return $this->page;
+    }
+
+    public function getPerPage(): int
+    {
+        return $this->perPage;
+    }
+}

--- a/backend/src/Audience/Site/Application/Query/ViewCatalogHomePage/ViewCatalogHomePageQueryHandler.php
+++ b/backend/src/Audience/Site/Application/Query/ViewCatalogHomePage/ViewCatalogHomePageQueryHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Audience\Site\Application\Query\ViewCatalogHomePage;
+
+use Catalog\Application\Service\CatalogReadService;
+use SharedKernel\Application\CqrsMessageBus\Queries\QueryHandlerInterface;
+
+final class ViewCatalogHomePageQueryHandler implements QueryHandlerInterface
+{
+    private CatalogReadService $catalog;
+
+    public function __construct(CatalogReadService $catalog)
+    {
+        $this->catalog = $catalog;
+    }
+
+    public function __invoke(ViewCatalogHomePageQuery $query): ViewCatalogHomePageResponse
+    {
+        $products = $this->catalog->searchProducts(
+            $query->getFilters(),
+            $query->getPage(),
+            $query->getPerPage()
+        );
+        $facets = $this->catalog->getFilterFacets();
+
+        return new ViewCatalogHomePageResponse($products, $facets);
+    }
+}

--- a/backend/src/Audience/Site/Application/Query/ViewCatalogHomePage/ViewCatalogHomePageResponse.php
+++ b/backend/src/Audience/Site/Application/Query/ViewCatalogHomePage/ViewCatalogHomePageResponse.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Audience\Site\Application\Query\ViewCatalogHomePage;
+
+use Catalog\Application\ReadModel\FilterFacets;
+use Catalog\Application\ReadModel\ProductSearchResult;
+use SharedKernel\Application\CqrsMessageBus\Queries\QueryResponseInterface;
+
+final class ViewCatalogHomePageResponse implements QueryResponseInterface
+{
+    private ProductSearchResult $products;
+    private FilterFacets $facets;
+
+    public function __construct(ProductSearchResult $products, FilterFacets $facets)
+    {
+        $this->products = $products;
+        $this->facets = $facets;
+    }
+
+    public function getProducts(): ProductSearchResult
+    {
+        return $this->products;
+    }
+
+    public function getFacets(): FilterFacets
+    {
+        return $this->facets;
+    }
+}

--- a/backend/src/Audience/Site/Infrastructure/CqrsMessageBus/SiteQueryHandlerRegistry.php
+++ b/backend/src/Audience/Site/Infrastructure/CqrsMessageBus/SiteQueryHandlerRegistry.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Audience\Site\Infrastructure\CqrsMessageBus;
+
+use Audience\Site\Application\Query\SearchCatalogProducts\SearchCatalogProductsQuery;
+use Audience\Site\Application\Query\SearchCatalogProducts\SearchCatalogProductsQueryHandler;
+use Audience\Site\Application\Query\ViewCatalogHomePage\ViewCatalogHomePageQuery;
+use Audience\Site\Application\Query\ViewCatalogHomePage\ViewCatalogHomePageQueryHandler;
+use SharedKernel\Infrastructure\CqrsMessageBus\QueryHandlerRegistryInterface;
+
+final class SiteQueryHandlerRegistry implements QueryHandlerRegistryInterface
+{
+    public function getQueryHandlers(): array
+    {
+        return [
+            ViewCatalogHomePageQuery::class => ViewCatalogHomePageQueryHandler::class,
+            SearchCatalogProductsQuery::class => SearchCatalogProductsQueryHandler::class,
+        ];
+    }
+}

--- a/backend/src/Audience/Site/Infrastructure/Security/SiteSecurityConfig.php
+++ b/backend/src/Audience/Site/Infrastructure/Security/SiteSecurityConfig.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Audience\Site\Infrastructure\Security;
+
+use Audience\Site\Application\Query\SearchCatalogProducts\SearchCatalogProductsQuery;
+use Audience\Site\Application\Query\ViewCatalogHomePage\ViewCatalogHomePageQuery;
+use SharedKernel\Domain\Security\SecurityConfigInterface;
+
+final class SiteSecurityConfig implements SecurityConfigInterface
+{
+    public function getCommandPermissions(): array
+    {
+        return [];
+    }
+
+    public function getQueryPermissions(): array
+    {
+        return [
+            ViewCatalogHomePageQuery::class => null,
+            SearchCatalogProductsQuery::class => null,
+        ];
+    }
+
+    public function getRolePermissions(): array
+    {
+        return [];
+    }
+}

--- a/backend/src/Audience/Site/Infrastructure/Security/SiteSecurityConfigRegistry.php
+++ b/backend/src/Audience/Site/Infrastructure/Security/SiteSecurityConfigRegistry.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Audience\Site\Infrastructure\Security;
+
+use SharedKernel\Domain\Security\SecurityConfigRegistryInterface;
+
+final class SiteSecurityConfigRegistry implements SecurityConfigRegistryInterface
+{
+    private SiteSecurityConfig $config;
+
+    public function __construct(SiteSecurityConfig $config)
+    {
+        $this->config = $config;
+    }
+
+    public function getSecurityConfigs(): array
+    {
+        return [$this->config];
+    }
+}

--- a/backend/src/Catalog/Application/ReadModel/FilterFacets.php
+++ b/backend/src/Catalog/Application/ReadModel/FilterFacets.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Catalog\Application\ReadModel;
+
+use Catalog\Domain\ValueObjects\Brand;
+use Catalog\Domain\ValueObjects\Category;
+use SharedKernel\Application\CqrsMessageBus\Queries\QueryResponseInterface;
+
+final class FilterFacets implements QueryResponseInterface
+{
+    /** @var Category[] */
+    private array $categories;
+    /** @var Brand[] */
+    private array $brands;
+    private int $priceMin;
+    private int $priceMax;
+
+    /**
+     * @param Category[] $categories
+     * @param Brand[] $brands
+     */
+    public function __construct(array $categories, array $brands, int $priceMin, int $priceMax)
+    {
+        $this->categories = array_values($categories);
+        $this->brands = array_values($brands);
+        $this->priceMin = max(0, $priceMin);
+        $this->priceMax = max($this->priceMin, $priceMax);
+    }
+
+    /** @return Category[] */
+    public function getCategories(): array
+    {
+        return $this->categories;
+    }
+
+    /** @return Brand[] */
+    public function getBrands(): array
+    {
+        return $this->brands;
+    }
+
+    public function getPriceMin(): int
+    {
+        return $this->priceMin;
+    }
+
+    public function getPriceMax(): int
+    {
+        return $this->priceMax;
+    }
+}

--- a/backend/src/Catalog/Application/ReadModel/ProductListItem.php
+++ b/backend/src/Catalog/Application/ReadModel/ProductListItem.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Catalog\Application\ReadModel;
+
+final class ProductListItem
+{
+    private string $id;
+    private string $name;
+    private string $brandName;
+    private string $categoryName;
+    private string $priceFormatted;
+    private string $imageUrl;
+    private string $summary;
+
+    public function __construct(
+        string $id,
+        string $name,
+        string $brandName,
+        string $categoryName,
+        string $priceFormatted,
+        string $imageUrl,
+        string $summary
+    ) {
+        $this->id = $id;
+        $this->name = $name;
+        $this->brandName = $brandName;
+        $this->categoryName = $categoryName;
+        $this->priceFormatted = $priceFormatted;
+        $this->imageUrl = $imageUrl;
+        $this->summary = $summary;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getBrandName(): string
+    {
+        return $this->brandName;
+    }
+
+    public function getCategoryName(): string
+    {
+        return $this->categoryName;
+    }
+
+    public function getPriceFormatted(): string
+    {
+        return $this->priceFormatted;
+    }
+
+    public function getImageUrl(): string
+    {
+        return $this->imageUrl;
+    }
+
+    public function getSummary(): string
+    {
+        return $this->summary;
+    }
+}

--- a/backend/src/Catalog/Application/ReadModel/ProductSearchResult.php
+++ b/backend/src/Catalog/Application/ReadModel/ProductSearchResult.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Catalog\Application\ReadModel;
+
+use SharedKernel\Application\CqrsMessageBus\Queries\QueryResponseInterface;
+
+final class ProductSearchResult implements QueryResponseInterface
+{
+    /** @var ProductListItem[] */
+    private array $items;
+    private int $total;
+    private int $page;
+    private int $perPage;
+    private int $totalPages;
+
+    /**
+     * @param ProductListItem[] $items
+     */
+    public function __construct(array $items, int $total, int $page, int $perPage)
+    {
+        $this->items = array_values($items);
+        $this->total = max(0, $total);
+        $this->page = max(1, $page);
+        $this->perPage = max(1, $perPage);
+        $this->totalPages = $this->total === 0 ? 0 : (int) ceil($this->total / $this->perPage);
+    }
+
+    /** @return ProductListItem[] */
+    public function getItems(): array
+    {
+        return $this->items;
+    }
+
+    public function getTotal(): int
+    {
+        return $this->total;
+    }
+
+    public function getPage(): int
+    {
+        return $this->page;
+    }
+
+    public function getPerPage(): int
+    {
+        return $this->perPage;
+    }
+
+    public function getTotalPages(): int
+    {
+        return $this->totalPages;
+    }
+}

--- a/backend/src/Catalog/Application/ReadModel/SearchFilters.php
+++ b/backend/src/Catalog/Application/ReadModel/SearchFilters.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Catalog\Application\ReadModel;
+
+final class SearchFilters
+{
+    /** @var string[] */
+    private array $categoryIds;
+    /** @var string[] */
+    private array $brandIds;
+    private ?int $priceMin;
+    private ?int $priceMax;
+    private ?string $searchTerm;
+
+    /**
+     * @param string[] $categoryIds
+     * @param string[] $brandIds
+     */
+    public function __construct(
+        array $categoryIds = [],
+        array $brandIds = [],
+        ?int $priceMin = null,
+        ?int $priceMax = null,
+        ?string $searchTerm = null
+    ) {
+        $this->categoryIds = self::stringValues($categoryIds);
+        $this->brandIds = self::stringValues($brandIds);
+        $this->priceMin = $priceMin;
+        $this->priceMax = $priceMax;
+        $this->searchTerm = $searchTerm !== null && trim($searchTerm) !== '' ? trim($searchTerm) : null;
+    }
+
+    /**
+     * Builds filters from an untrusted HTTP query-string array (e.g. $_GET).
+     * Performs coercion only — no rejection, no errors: missing/garbage values resolve to null/empty.
+     *
+     * @param array<string, mixed> $raw
+     */
+    public static function fromHttpInput(array $raw): self
+    {
+        return new self(
+            self::stringValues(self::asArray($raw['category'] ?? [])),
+            self::stringValues(self::asArray($raw['brand'] ?? [])),
+            self::nullableInt($raw['price_min'] ?? null),
+            self::nullableInt($raw['price_max'] ?? null),
+            is_string($raw['q'] ?? null) ? $raw['q'] : null
+        );
+    }
+
+    /**
+     * @param mixed $value
+     * @return array<int, mixed>
+     */
+    private static function asArray($value): array
+    {
+        return is_array($value) ? array_values($value) : [];
+    }
+
+    /**
+     * @param array<int, mixed> $values
+     * @return string[]
+     */
+    private static function stringValues(array $values): array
+    {
+        $result = [];
+        foreach ($values as $v) {
+            if (!is_string($v) || $v === '') {
+                continue;
+            }
+            $result[] = $v;
+        }
+        return $result;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function nullableInt($value): ?int
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        if (is_int($value)) {
+            return $value;
+        }
+        if (is_string($value) && preg_match('/^-?\d+$/', $value) === 1) {
+            return (int) $value;
+        }
+        return null;
+    }
+
+    /** @return string[] */
+    public function getCategoryIds(): array
+    {
+        return $this->categoryIds;
+    }
+
+    /** @return string[] */
+    public function getBrandIds(): array
+    {
+        return $this->brandIds;
+    }
+
+    public function getPriceMin(): ?int
+    {
+        return $this->priceMin;
+    }
+
+    public function getPriceMax(): ?int
+    {
+        return $this->priceMax;
+    }
+
+    public function getSearchTerm(): ?string
+    {
+        return $this->searchTerm;
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->categoryIds === []
+            && $this->brandIds === []
+            && $this->priceMin === null
+            && $this->priceMax === null
+            && $this->searchTerm === null;
+    }
+
+    /**
+     * Roundtrips into the URL query string.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $result = [];
+        if ($this->categoryIds !== []) {
+            $result['category'] = $this->categoryIds;
+        }
+        if ($this->brandIds !== []) {
+            $result['brand'] = $this->brandIds;
+        }
+        if ($this->priceMin !== null) {
+            $result['price_min'] = $this->priceMin;
+        }
+        if ($this->priceMax !== null) {
+            $result['price_max'] = $this->priceMax;
+        }
+        if ($this->searchTerm !== null) {
+            $result['q'] = $this->searchTerm;
+        }
+        return $result;
+    }
+}

--- a/backend/src/Catalog/Application/Service/CatalogReadService.php
+++ b/backend/src/Catalog/Application/Service/CatalogReadService.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Catalog\Application\Service;
+
+use Catalog\Application\ReadModel\FilterFacets;
+use Catalog\Application\ReadModel\ProductListItem;
+use Catalog\Application\ReadModel\ProductSearchResult;
+use Catalog\Application\ReadModel\SearchFilters;
+use Catalog\Domain\Product;
+use Catalog\Domain\Repository\ProductRepositoryInterface;
+use Catalog\Domain\ValueObjects\Brand;
+use Catalog\Domain\ValueObjects\Category;
+
+/**
+ * Public application-layer API of the Catalog bounded context for read operations.
+ *
+ * Audience handlers (e.g. Audience\Site\...) call this service directly — there is no
+ * CQRS bus dispatch at this boundary, because cross-cutting decorators (throttle/security/log)
+ * already ran at the audience query that called us. Inside the BC, this is just a typed
+ * facade over the repository plus presentation-shape mapping.
+ */
+final class CatalogReadService
+{
+    private const PER_PAGE_FALLBACK = 12;
+
+    private ProductRepositoryInterface $repository;
+
+    public function __construct(ProductRepositoryInterface $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function searchProducts(SearchFilters $filters, int $page, int $perPage): ProductSearchResult
+    {
+        $page = $page < 1 ? 1 : $page;
+        $perPage = $perPage < 1 ? self::PER_PAGE_FALLBACK : $perPage;
+
+        $result = $this->repository->findByFilters($filters, $page, $perPage);
+
+        $facets = $this->repository->getFacets();
+        $brandsById = $this->indexBrandsById($facets['brands']);
+        $categoriesById = $this->indexCategoriesById($facets['categories']);
+
+        $items = [];
+        foreach ($result['products'] as $product) {
+            $items[] = $this->toListItem($product, $brandsById, $categoriesById);
+        }
+
+        return new ProductSearchResult($items, $result['total'], $page, $perPage);
+    }
+
+    public function getFilterFacets(): FilterFacets
+    {
+        $facets = $this->repository->getFacets();
+
+        return new FilterFacets(
+            $facets['categories'],
+            $facets['brands'],
+            $facets['priceMin'],
+            $facets['priceMax']
+        );
+    }
+
+    /**
+     * @param array<string, Brand> $brandsById
+     * @param array<string, Category> $categoriesById
+     */
+    private function toListItem(Product $product, array $brandsById, array $categoriesById): ProductListItem
+    {
+        $brand = $brandsById[$product->getBrandId()] ?? null;
+        $category = $categoriesById[$product->getCategoryId()] ?? null;
+
+        return new ProductListItem(
+            $product->getId()->toString(),
+            $product->getName(),
+            $brand !== null ? $brand->getName() : '',
+            $category !== null ? $category->getName() : '',
+            $product->getPrice()->format(),
+            $product->getImageUrl(),
+            $product->getSummary()
+        );
+    }
+
+    /**
+     * @param Brand[] $brands
+     * @return array<string, Brand>
+     */
+    private function indexBrandsById(array $brands): array
+    {
+        $result = [];
+        foreach ($brands as $brand) {
+            $result[$brand->getId()] = $brand;
+        }
+        return $result;
+    }
+
+    /**
+     * @param Category[] $categories
+     * @return array<string, Category>
+     */
+    private function indexCategoriesById(array $categories): array
+    {
+        $result = [];
+        foreach ($categories as $category) {
+            $result[$category->getId()] = $category;
+        }
+        return $result;
+    }
+}

--- a/backend/src/Catalog/Domain/Product.php
+++ b/backend/src/Catalog/Domain/Product.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Catalog\Domain;
+
+use Catalog\Domain\ValueObjects\Price;
+use Catalog\Domain\ValueObjects\ProductId;
+
+final class Product
+{
+    private ProductId $id;
+    private string $name;
+    private string $brandId;
+    private string $categoryId;
+    private Price $price;
+    private string $imageUrl;
+    private string $summary;
+
+    public function __construct(
+        ProductId $id,
+        string $name,
+        string $brandId,
+        string $categoryId,
+        Price $price,
+        string $imageUrl,
+        string $summary
+    ) {
+        $this->id = $id;
+        $this->name = $name;
+        $this->brandId = $brandId;
+        $this->categoryId = $categoryId;
+        $this->price = $price;
+        $this->imageUrl = $imageUrl;
+        $this->summary = $summary;
+    }
+
+    public function getId(): ProductId
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getBrandId(): string
+    {
+        return $this->brandId;
+    }
+
+    public function getCategoryId(): string
+    {
+        return $this->categoryId;
+    }
+
+    public function getPrice(): Price
+    {
+        return $this->price;
+    }
+
+    public function getImageUrl(): string
+    {
+        return $this->imageUrl;
+    }
+
+    public function getSummary(): string
+    {
+        return $this->summary;
+    }
+}

--- a/backend/src/Catalog/Domain/Repository/ProductRepositoryInterface.php
+++ b/backend/src/Catalog/Domain/Repository/ProductRepositoryInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Catalog\Domain\Repository;
+
+use Catalog\Application\ReadModel\SearchFilters;
+
+interface ProductRepositoryInterface
+{
+    /**
+     * Returns matching products plus the total count for pagination.
+     *
+     * @return array{products: \Catalog\Domain\Product[], total: int}
+     */
+    public function findByFilters(SearchFilters $filters, int $page, int $perPage): array;
+
+    /**
+     * Returns snapshot of available facets — categories, brands, and global price bounds.
+     *
+     * @return array{
+     *     categories: \Catalog\Domain\ValueObjects\Category[],
+     *     brands: \Catalog\Domain\ValueObjects\Brand[],
+     *     priceMin: int,
+     *     priceMax: int
+     * }
+     */
+    public function getFacets(): array;
+}

--- a/backend/src/Catalog/Domain/ValueObjects/Brand.php
+++ b/backend/src/Catalog/Domain/ValueObjects/Brand.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Catalog\Domain\ValueObjects;
+
+use InvalidArgumentException;
+
+final class Brand
+{
+    private string $id;
+    private string $name;
+
+    public function __construct(string $id, string $name)
+    {
+        $id = trim($id);
+        $name = trim($name);
+        if ($id === '') {
+            throw new InvalidArgumentException('Brand id cannot be empty.');
+        }
+        if ($name === '') {
+            throw new InvalidArgumentException('Brand name cannot be empty.');
+        }
+        $this->id = $id;
+        $this->name = $name;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}

--- a/backend/src/Catalog/Domain/ValueObjects/Category.php
+++ b/backend/src/Catalog/Domain/ValueObjects/Category.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Catalog\Domain\ValueObjects;
+
+use InvalidArgumentException;
+
+final class Category
+{
+    private string $id;
+    private string $name;
+    private string $slug;
+
+    public function __construct(string $id, string $name, string $slug)
+    {
+        $id = trim($id);
+        $name = trim($name);
+        $slug = trim($slug);
+        if ($id === '') {
+            throw new InvalidArgumentException('Category id cannot be empty.');
+        }
+        if ($name === '') {
+            throw new InvalidArgumentException('Category name cannot be empty.');
+        }
+        if ($slug === '') {
+            throw new InvalidArgumentException('Category slug cannot be empty.');
+        }
+        $this->id = $id;
+        $this->name = $name;
+        $this->slug = $slug;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+}

--- a/backend/src/Catalog/Domain/ValueObjects/Price.php
+++ b/backend/src/Catalog/Domain/ValueObjects/Price.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Catalog\Domain\ValueObjects;
+
+use InvalidArgumentException;
+
+final class Price
+{
+    private int $amount;
+    private string $currency;
+
+    public function __construct(int $amount, string $currency)
+    {
+        if ($amount < 0) {
+            throw new InvalidArgumentException('Price amount cannot be negative.');
+        }
+        $currency = strtoupper(trim($currency));
+        if (strlen($currency) !== 3) {
+            throw new InvalidArgumentException('Currency must be a 3-letter ISO 4217 code.');
+        }
+        $this->amount = $amount;
+        $this->currency = $currency;
+    }
+
+    public function getAmount(): int
+    {
+        return $this->amount;
+    }
+
+    public function getCurrency(): string
+    {
+        return $this->currency;
+    }
+
+    public function format(): string
+    {
+        $major = intdiv($this->amount, 100);
+        $minor = $this->amount % 100;
+        $symbol = $this->currency === 'USD' ? '$' : $this->currency . ' ';
+        return sprintf('%s%d.%02d', $symbol, $major, $minor);
+    }
+
+    public function equals(Price $other): bool
+    {
+        return $this->amount === $other->amount && $this->currency === $other->currency;
+    }
+}

--- a/backend/src/Catalog/Domain/ValueObjects/ProductId.php
+++ b/backend/src/Catalog/Domain/ValueObjects/ProductId.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Catalog\Domain\ValueObjects;
+
+use InvalidArgumentException;
+
+final class ProductId
+{
+    private string $value;
+
+    public function __construct(string $value)
+    {
+        $value = trim($value);
+        if ($value === '') {
+            throw new InvalidArgumentException('ProductId cannot be empty.');
+        }
+        $this->value = $value;
+    }
+
+    public static function fromString(string $value): self
+    {
+        return new self($value);
+    }
+
+    public function toString(): string
+    {
+        return $this->value;
+    }
+
+    public function equals(ProductId $other): bool
+    {
+        return $this->value === $other->value;
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/backend/src/Catalog/Infrastructure/Repository/InMemoryProductRepository.php
+++ b/backend/src/Catalog/Infrastructure/Repository/InMemoryProductRepository.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Catalog\Infrastructure\Repository;
+
+use Catalog\Application\ReadModel\SearchFilters;
+use Catalog\Domain\Product;
+use Catalog\Domain\Repository\ProductRepositoryInterface;
+use Catalog\Domain\ValueObjects\Brand;
+use Catalog\Domain\ValueObjects\Category;
+use Catalog\Domain\ValueObjects\Price;
+use Catalog\Domain\ValueObjects\ProductId;
+
+final class InMemoryProductRepository implements ProductRepositoryInterface
+{
+    /** @var Category[] */
+    private array $categories;
+    /** @var Brand[] */
+    private array $brands;
+    /** @var Product[] */
+    private array $products;
+
+    public function __construct()
+    {
+        $this->categories = [
+            new Category('cat-electronics', 'Electronics', 'electronics'),
+            new Category('cat-books', 'Books', 'books'),
+            new Category('cat-clothing', 'Clothing', 'clothing'),
+            new Category('cat-home', 'Home & Kitchen', 'home'),
+            new Category('cat-toys', 'Toys & Games', 'toys'),
+        ];
+
+        $this->brands = [
+            new Brand('brand-acme', 'Acme'),
+            new Brand('brand-globex', 'Globex'),
+            new Brand('brand-initech', 'Initech'),
+            new Brand('brand-umbrella', 'Umbrella'),
+            new Brand('brand-stark', 'Stark'),
+            new Brand('brand-wayne', 'Wayne'),
+        ];
+
+        $this->products = $this->seedProducts();
+    }
+
+    public function findByFilters(SearchFilters $filters, int $page, int $perPage): array
+    {
+        $matched = array_values(array_filter(
+            $this->products,
+            fn (Product $p): bool => $this->matches($p, $filters)
+        ));
+
+        usort($matched, static fn (Product $a, Product $b): int => strcmp($a->getName(), $b->getName()));
+
+        $total = count($matched);
+        $offset = ($page - 1) * $perPage;
+        $slice = $offset >= $total ? [] : array_slice($matched, $offset, $perPage);
+
+        return ['products' => $slice, 'total' => $total];
+    }
+
+    public function getFacets(): array
+    {
+        $prices = array_map(static fn (Product $p): int => $p->getPrice()->getAmount(), $this->products);
+
+        return [
+            'categories' => $this->categories,
+            'brands' => $this->brands,
+            'priceMin' => $prices === [] ? 0 : min($prices),
+            'priceMax' => $prices === [] ? 0 : max($prices),
+        ];
+    }
+
+    private function matches(Product $product, SearchFilters $filters): bool
+    {
+        $categoryIds = $filters->getCategoryIds();
+        if ($categoryIds !== [] && !in_array($product->getCategoryId(), $categoryIds, true)) {
+            return false;
+        }
+        $brandIds = $filters->getBrandIds();
+        if ($brandIds !== [] && !in_array($product->getBrandId(), $brandIds, true)) {
+            return false;
+        }
+        $amount = $product->getPrice()->getAmount();
+        if ($filters->getPriceMin() !== null && $amount < $filters->getPriceMin()) {
+            return false;
+        }
+        if ($filters->getPriceMax() !== null && $amount > $filters->getPriceMax()) {
+            return false;
+        }
+        return $filters->getSearchTerm() === null || stripos($product->getName(), $filters->getSearchTerm()) !== false;
+    }
+
+    /**
+     * @return Product[]
+     */
+    private function seedProducts(): array
+    {
+        $rows = [
+            ['p01', 'Wireless Headphones', 'brand-stark', 'cat-electronics', 12999, 'Over-ear noise-cancelling cans.'],
+            ['p02', 'Bluetooth Speaker', 'brand-acme', 'cat-electronics', 4999, 'Pocket-sized, all-day battery.'],
+            ['p03', 'USB-C Charger 65W', 'brand-initech', 'cat-electronics', 2499, 'GaN tech, three ports.'],
+            ['p04', 'Mechanical Keyboard', 'brand-wayne', 'cat-electronics', 8999, 'Hot-swappable, RGB optional.'],
+            ['p05', '4K Webcam', 'brand-globex', 'cat-electronics', 6999, 'Auto-focus, dual mics.'],
+            ['p06', 'Domain-Driven Design', 'brand-acme', 'cat-books', 3499, 'Eric Evans, the blue book.'],
+            ['p07', 'Refactoring', 'brand-acme', 'cat-books', 2999, 'Fowler, 2nd edition.'],
+            ['p08', 'The Pragmatic Programmer','brand-globex', 'cat-books', 2799, 'Hunt & Thomas.'],
+            ['p09', 'Cotton T-Shirt', 'brand-umbrella', 'cat-clothing', 1499, 'Heavyweight, garment-dyed.'],
+            ['p10', 'Denim Jeans', 'brand-umbrella', 'cat-clothing', 5999, 'Selvedge, slim fit.'],
+            ['p11', 'Wool Sweater', 'brand-stark', 'cat-clothing', 7999, 'Merino, fisherman knit.'],
+            ['p12', 'Running Shoes', 'brand-wayne', 'cat-clothing', 9999, 'Lightweight trainers.'],
+            ['p13', 'Coffee Grinder', 'brand-initech', 'cat-home', 8499, 'Conical burr, 40 settings.'],
+            ['p14', 'Cast Iron Skillet', 'brand-acme', 'cat-home', 3999, '10 inch, pre-seasoned.'],
+            ['p15', 'Chef Knife', 'brand-stark', 'cat-home', 6499, '8 inch, German steel.'],
+            ['p16', 'Espresso Machine', 'brand-globex', 'cat-home', 29999, 'Dual boiler, PID.'],
+            ['p17', 'Board Game: Catan', 'brand-wayne', 'cat-toys', 3999, 'Trade, build, settle.'],
+            ['p18', 'LEGO Architecture Set', 'brand-umbrella', 'cat-toys', 4999, '500+ pieces.'],
+            ['p19', 'Drone Kit', 'brand-initech', 'cat-toys', 14999, '4K camera, foldable.'],
+            ['p20', 'Puzzle 1000 pcs', 'brand-acme', 'cat-toys', 1999, 'Scenic landscape.'],
+        ];
+
+        $products = [];
+        foreach ($rows as $r) {
+            [$id, $name, $brandId, $categoryId, $cents, $summary] = $r;
+            $products[] = new Product(
+                new ProductId($id),
+                $name,
+                $brandId,
+                $categoryId,
+                new Price($cents, 'USD'),
+                $this->placeholderImage($id, $name),
+                $summary
+            );
+        }
+        return $products;
+    }
+
+    private function placeholderImage(string $id, string $name): string
+    {
+        $hue = crc32($id) % 360;
+        $bg = "hsl($hue, 60%, 75%)";
+        $fg = "hsl($hue, 60%, 25%)";
+        $initials = strtoupper(substr($name, 0, 2));
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">'
+            . '<rect width="200" height="200" fill="' . $bg . '"/>'
+            . '<text x="100" y="115" font-family="sans-serif" font-size="60" font-weight="700" '
+            . 'text-anchor="middle" fill="' . $fg . '">' . htmlspecialchars($initials, ENT_XML1, 'UTF-8') . '</text>'
+            . '</svg>';
+        return 'data:image/svg+xml;utf8,' . rawurlencode($svg);
+    }
+}

--- a/backend/tests/Fixtures/Catalog/StubProductRepository.php
+++ b/backend/tests/Fixtures/Catalog/StubProductRepository.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Catalog;
+
+use Catalog\Application\ReadModel\SearchFilters;
+use Catalog\Domain\Product;
+use Catalog\Domain\Repository\ProductRepositoryInterface;
+use Catalog\Domain\ValueObjects\Brand;
+use Catalog\Domain\ValueObjects\Category;
+
+final class StubProductRepository implements ProductRepositoryInterface
+{
+    /** @var Product[] */
+    public array $products;
+    public int $total;
+    /** @var Category[] */
+    public array $categories;
+    /** @var Brand[] */
+    public array $brands;
+    public int $priceMin = 0;
+    public int $priceMax = 0;
+
+    public ?SearchFilters $lastFilters = null;
+    public ?int $lastPage = null;
+    public ?int $lastPerPage = null;
+
+    /**
+     * @param Product[] $products
+     * @param Category[] $categories
+     * @param Brand[] $brands
+     */
+    public function __construct(array $products = [], int $total = 0, array $categories = [], array $brands = [])
+    {
+        $this->products = $products;
+        $this->total = $total;
+        $this->categories = $categories;
+        $this->brands = $brands;
+    }
+
+    public function findByFilters(SearchFilters $filters, int $page, int $perPage): array
+    {
+        $this->lastFilters = $filters;
+        $this->lastPage = $page;
+        $this->lastPerPage = $perPage;
+        return ['products' => $this->products, 'total' => $this->total];
+    }
+
+    public function getFacets(): array
+    {
+        return [
+            'categories' => $this->categories,
+            'brands' => $this->brands,
+            'priceMin' => $this->priceMin,
+            'priceMax' => $this->priceMax,
+        ];
+    }
+}

--- a/backend/tests/Unit/Audience/Site/Application/Query/SearchCatalogProducts/SearchCatalogProductsQueryHandlerTest.php
+++ b/backend/tests/Unit/Audience/Site/Application/Query/SearchCatalogProducts/SearchCatalogProductsQueryHandlerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Audience\Site\Application\Query\SearchCatalogProducts;
+
+use Audience\Site\Application\Query\SearchCatalogProducts\SearchCatalogProductsQuery;
+use Audience\Site\Application\Query\SearchCatalogProducts\SearchCatalogProductsQueryHandler;
+use Audience\Site\Application\Query\SearchCatalogProducts\SearchCatalogProductsResponse;
+use Catalog\Application\ReadModel\ProductSearchResult;
+use Catalog\Application\ReadModel\SearchFilters;
+use Catalog\Application\Service\CatalogReadService;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\Catalog\StubProductRepository;
+
+class SearchCatalogProductsQueryHandlerTest extends TestCase
+{
+    public function testDelegatesToCatalogServiceWithPassedFiltersAndPage(): void
+    {
+        $repo = new StubProductRepository([], 42);
+        $handler = new SearchCatalogProductsQueryHandler(new CatalogReadService($repo));
+
+        $filters = new SearchFilters(['cat-1'], ['brand-a']);
+        $response = $handler(new SearchCatalogProductsQuery($filters, 4, 20));
+
+        $this->assertInstanceOf(SearchCatalogProductsResponse::class, $response);
+        $result = $response->getResult();
+        $this->assertInstanceOf(ProductSearchResult::class, $result);
+        $this->assertSame(42, $result->getTotal());
+        $this->assertSame(4, $result->getPage());
+        $this->assertSame($filters, $repo->lastFilters);
+        $this->assertSame(4, $repo->lastPage);
+        $this->assertSame(20, $repo->lastPerPage);
+    }
+}

--- a/backend/tests/Unit/Audience/Site/Application/Query/SearchCatalogProducts/SearchCatalogProductsQueryTest.php
+++ b/backend/tests/Unit/Audience/Site/Application/Query/SearchCatalogProducts/SearchCatalogProductsQueryTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Audience\Site\Application\Query\SearchCatalogProducts;
+
+use Audience\Site\Application\Query\SearchCatalogProducts\SearchCatalogProductsQuery;
+use PHPUnit\Framework\TestCase;
+
+class SearchCatalogProductsQueryTest extends TestCase
+{
+    public function testFromHttpInputDefaultsToPageOneWhenAbsent(): void
+    {
+        $q = SearchCatalogProductsQuery::fromHttpInput([]);
+        $this->assertSame(1, $q->getPage());
+    }
+
+    public function testFromHttpInputParsesNumericStringPage(): void
+    {
+        $q = SearchCatalogProductsQuery::fromHttpInput(['page' => '3']);
+        $this->assertSame(3, $q->getPage());
+    }
+
+    public function testFromHttpInputAcceptsIntPage(): void
+    {
+        $q = SearchCatalogProductsQuery::fromHttpInput(['page' => 5]);
+        $this->assertSame(5, $q->getPage());
+    }
+
+    public function testFromHttpInputCoercesNonNumericPageToOne(): void
+    {
+        $q = SearchCatalogProductsQuery::fromHttpInput(['page' => 'abc']);
+        $this->assertSame(1, $q->getPage());
+    }
+
+    public function testFromHttpInputCoercesNegativePageToOne(): void
+    {
+        $q = SearchCatalogProductsQuery::fromHttpInput(['page' => '-2']);
+        $this->assertSame(1, $q->getPage());
+    }
+
+    public function testFromHttpInputCoercesZeroPageToOne(): void
+    {
+        $q = SearchCatalogProductsQuery::fromHttpInput(['page' => 0]);
+        $this->assertSame(1, $q->getPage());
+    }
+
+    public function testFromHttpInputBuildsFiltersFromSameInput(): void
+    {
+        $q = SearchCatalogProductsQuery::fromHttpInput([
+            'category' => ['cat-1'],
+            'page' => '2',
+        ]);
+        $this->assertSame(['cat-1'], $q->getFilters()->getCategoryIds());
+        $this->assertSame(2, $q->getPage());
+    }
+}

--- a/backend/tests/Unit/Audience/Site/Application/Query/ViewCatalogHomePage/ViewCatalogHomePageQueryHandlerTest.php
+++ b/backend/tests/Unit/Audience/Site/Application/Query/ViewCatalogHomePage/ViewCatalogHomePageQueryHandlerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Audience\Site\Application\Query\ViewCatalogHomePage;
+
+use Audience\Site\Application\Query\ViewCatalogHomePage\ViewCatalogHomePageQuery;
+use Audience\Site\Application\Query\ViewCatalogHomePage\ViewCatalogHomePageQueryHandler;
+use Catalog\Application\ReadModel\SearchFilters;
+use Catalog\Application\Service\CatalogReadService;
+use Catalog\Domain\ValueObjects\Brand;
+use Catalog\Domain\ValueObjects\Category;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\Catalog\StubProductRepository;
+
+class ViewCatalogHomePageQueryHandlerTest extends TestCase
+{
+    public function testComposesProductsAndFacetsViaCatalogService(): void
+    {
+        $repo = new StubProductRepository(
+            [],
+            0,
+            [new Category('c1', 'Electronics', 'electronics')],
+            [new Brand('b1', 'Acme')]
+        );
+        $repo->priceMin = 1000;
+        $repo->priceMax = 5000;
+
+        $handler = new ViewCatalogHomePageQueryHandler(new CatalogReadService($repo));
+
+        $response = $handler(new ViewCatalogHomePageQuery(new SearchFilters(), 1));
+
+        $this->assertSame(0, $response->getProducts()->getTotal());
+        $this->assertCount(1, $response->getFacets()->getCategories());
+        $this->assertCount(1, $response->getFacets()->getBrands());
+        $this->assertSame(1000, $response->getFacets()->getPriceMin());
+        $this->assertSame(5000, $response->getFacets()->getPriceMax());
+    }
+
+    public function testForwardsFiltersAndPageToCatalogService(): void
+    {
+        $repo = new StubProductRepository([], 0);
+        $handler = new ViewCatalogHomePageQueryHandler(new CatalogReadService($repo));
+
+        $filters = new SearchFilters(['cat-1'], ['brand-a'], 100, 1000, 'widget');
+        $handler(new ViewCatalogHomePageQuery($filters, 3));
+
+        $this->assertSame($filters, $repo->lastFilters);
+        $this->assertSame(3, $repo->lastPage);
+    }
+}

--- a/backend/tests/Unit/Catalog/Application/ReadModel/SearchFiltersTest.php
+++ b/backend/tests/Unit/Catalog/Application/ReadModel/SearchFiltersTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Catalog\Application\ReadModel;
+
+use Catalog\Application\ReadModel\SearchFilters;
+use PHPUnit\Framework\TestCase;
+
+class SearchFiltersTest extends TestCase
+{
+    public function testFromHttpInputWithEmptyArrayProducesEmptyFilters(): void
+    {
+        $f = SearchFilters::fromHttpInput([]);
+        $this->assertTrue($f->isEmpty());
+    }
+
+    public function testFromHttpInputCoercesCategoryAndBrandArrays(): void
+    {
+        $f = SearchFilters::fromHttpInput([
+            'category' => ['cat-1', 'cat-2'],
+            'brand' => ['brand-a'],
+        ]);
+        $this->assertSame(['cat-1', 'cat-2'], $f->getCategoryIds());
+        $this->assertSame(['brand-a'], $f->getBrandIds());
+    }
+
+    public function testFromHttpInputDropsEmptyStringsFromArrays(): void
+    {
+        $f = SearchFilters::fromHttpInput([
+            'category' => ['cat-1', '', 'cat-2'],
+        ]);
+        $this->assertSame(['cat-1', 'cat-2'], $f->getCategoryIds());
+    }
+
+    public function testFromHttpInputDropsNonStringValuesFromArrays(): void
+    {
+        $f = SearchFilters::fromHttpInput([
+            'category' => ['cat-1', 42, null, ['nested'], 'cat-2'],
+        ]);
+        $this->assertSame(['cat-1', 'cat-2'], $f->getCategoryIds());
+    }
+
+    public function testFromHttpInputTreatsNonArrayCategoryAsEmpty(): void
+    {
+        $f = SearchFilters::fromHttpInput(['category' => 'not-an-array']);
+        $this->assertSame([], $f->getCategoryIds());
+    }
+
+    public function testFromHttpInputParsesNumericStringPriceBounds(): void
+    {
+        $f = SearchFilters::fromHttpInput([
+            'price_min' => '500',
+            'price_max' => '5000',
+        ]);
+        $this->assertSame(500, $f->getPriceMin());
+        $this->assertSame(5000, $f->getPriceMax());
+    }
+
+    public function testFromHttpInputTreatsEmptyPriceStringAsNull(): void
+    {
+        $f = SearchFilters::fromHttpInput([
+            'price_min' => '',
+            'price_max' => '',
+        ]);
+        $this->assertNull($f->getPriceMin());
+        $this->assertNull($f->getPriceMax());
+    }
+
+    public function testFromHttpInputRejectsNonNumericPriceStrings(): void
+    {
+        $f = SearchFilters::fromHttpInput([
+            'price_min' => 'abc',
+            'price_max' => '1.5',
+        ]);
+        $this->assertNull($f->getPriceMin());
+        $this->assertNull($f->getPriceMax());
+    }
+
+    public function testFromHttpInputAcceptsIntPriceBounds(): void
+    {
+        $f = SearchFilters::fromHttpInput([
+            'price_min' => 100,
+            'price_max' => 999,
+        ]);
+        $this->assertSame(100, $f->getPriceMin());
+        $this->assertSame(999, $f->getPriceMax());
+    }
+
+    public function testFromHttpInputTrimsSearchTerm(): void
+    {
+        $f = SearchFilters::fromHttpInput(['q' => '  hello  ']);
+        $this->assertSame('hello', $f->getSearchTerm());
+    }
+
+    public function testFromHttpInputTreatsBlankSearchTermAsNull(): void
+    {
+        $f = SearchFilters::fromHttpInput(['q' => '   ']);
+        $this->assertNull($f->getSearchTerm());
+    }
+
+    public function testFromHttpInputIgnoresNonStringSearchTerm(): void
+    {
+        $f = SearchFilters::fromHttpInput(['q' => ['not-a-string']]);
+        $this->assertNull($f->getSearchTerm());
+    }
+
+    public function testToArrayRoundtripsBackToHttpFormat(): void
+    {
+        $f = SearchFilters::fromHttpInput([
+            'category' => ['cat-1'],
+            'brand' => ['brand-a', 'brand-b'],
+            'price_min' => '500',
+            'q' => 'widget',
+        ]);
+        $this->assertSame([
+            'category' => ['cat-1'],
+            'brand' => ['brand-a', 'brand-b'],
+            'price_min' => 500,
+            'q' => 'widget',
+        ], $f->toArray());
+    }
+}

--- a/backend/tests/Unit/Catalog/Application/Service/CatalogReadServiceTest.php
+++ b/backend/tests/Unit/Catalog/Application/Service/CatalogReadServiceTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Catalog\Application\Service;
+
+use Catalog\Application\ReadModel\SearchFilters;
+use Catalog\Application\Service\CatalogReadService;
+use Catalog\Domain\Product;
+use Catalog\Domain\ValueObjects\Brand;
+use Catalog\Domain\ValueObjects\Category;
+use Catalog\Domain\ValueObjects\Price;
+use Catalog\Domain\ValueObjects\ProductId;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\Catalog\StubProductRepository;
+
+class CatalogReadServiceTest extends TestCase
+{
+    public function testSearchProductsReturnsItemsWithJoinedBrandAndCategoryNames(): void
+    {
+        $repo = new StubProductRepository(
+            [$this->makeProduct('p1', 'Widget', 'b1', 'c1', 1999)],
+            1,
+            [new Category('c1', 'Electronics', 'electronics')],
+            [new Brand('b1', 'Acme')]
+        );
+        $service = new CatalogReadService($repo);
+
+        $response = $service->searchProducts(new SearchFilters(), 1, 12);
+
+        $this->assertCount(1, $response->getItems());
+        $item = $response->getItems()[0];
+        $this->assertSame('p1', $item->getId());
+        $this->assertSame('Widget', $item->getName());
+        $this->assertSame('Acme', $item->getBrandName());
+        $this->assertSame('Electronics', $item->getCategoryName());
+        $this->assertSame('$19.99', $item->getPriceFormatted());
+    }
+
+    public function testSearchProductsPassesFiltersAndPaginationToRepository(): void
+    {
+        $repo = new StubProductRepository([], 0);
+        $service = new CatalogReadService($repo);
+
+        $filters = new SearchFilters(['c1'], ['b1'], 500, 5000, 'widget');
+        $service->searchProducts($filters, 3, 20);
+
+        $this->assertSame($filters, $repo->lastFilters);
+        $this->assertSame(3, $repo->lastPage);
+        $this->assertSame(20, $repo->lastPerPage);
+    }
+
+    public function testSearchProductsComputesTotalPagesFromTotalAndPerPage(): void
+    {
+        $repo = new StubProductRepository([], 25);
+        $service = new CatalogReadService($repo);
+
+        $response = $service->searchProducts(new SearchFilters(), 1, 10);
+
+        $this->assertSame(25, $response->getTotal());
+        $this->assertSame(3, $response->getTotalPages());
+    }
+
+    public function testSearchProductsEmptyResultReturnsZeroTotalPages(): void
+    {
+        $repo = new StubProductRepository([], 0);
+        $service = new CatalogReadService($repo);
+
+        $response = $service->searchProducts(new SearchFilters(), 1, 12);
+
+        $this->assertSame([], $response->getItems());
+        $this->assertSame(0, $response->getTotal());
+        $this->assertSame(0, $response->getTotalPages());
+    }
+
+    public function testSearchProductsCoercesZeroPageToOne(): void
+    {
+        $repo = new StubProductRepository([], 5);
+        $service = new CatalogReadService($repo);
+
+        $response = $service->searchProducts(new SearchFilters(), 0, 12);
+
+        $this->assertSame(1, $response->getPage());
+    }
+
+    public function testSearchProductsCoercesZeroPerPageToFallback(): void
+    {
+        $repo = new StubProductRepository([], 5);
+        $service = new CatalogReadService($repo);
+
+        $response = $service->searchProducts(new SearchFilters(), 1, 0);
+
+        $this->assertSame(12, $response->getPerPage());
+    }
+
+    public function testSearchProductsItemsForUnknownBrandFallBackToEmptyName(): void
+    {
+        $repo = new StubProductRepository(
+            [$this->makeProduct('p1', 'Widget', 'unknown-brand', 'c1', 1000)],
+            1,
+            [new Category('c1', 'Electronics', 'electronics')],
+            []
+        );
+        $service = new CatalogReadService($repo);
+
+        $response = $service->searchProducts(new SearchFilters(), 1, 12);
+
+        $this->assertSame('', $response->getItems()[0]->getBrandName());
+        $this->assertSame('Electronics', $response->getItems()[0]->getCategoryName());
+    }
+
+    public function testGetFilterFacetsReturnsCategoriesBrandsAndPriceRange(): void
+    {
+        $categories = [
+            new Category('c1', 'Electronics', 'electronics'),
+            new Category('c2', 'Books', 'books'),
+        ];
+        $brands = [
+            new Brand('b1', 'Acme'),
+            new Brand('b2', 'Globex'),
+        ];
+        $repo = new StubProductRepository([], 0, $categories, $brands);
+        $repo->priceMin = 500;
+        $repo->priceMax = 9999;
+
+        $service = new CatalogReadService($repo);
+        $response = $service->getFilterFacets();
+
+        $this->assertSame($categories, $response->getCategories());
+        $this->assertSame($brands, $response->getBrands());
+        $this->assertSame(500, $response->getPriceMin());
+        $this->assertSame(9999, $response->getPriceMax());
+    }
+
+    public function testGetFilterFacetsForEmptyRepository(): void
+    {
+        $service = new CatalogReadService(new StubProductRepository());
+
+        $response = $service->getFilterFacets();
+
+        $this->assertSame([], $response->getCategories());
+        $this->assertSame([], $response->getBrands());
+        $this->assertSame(0, $response->getPriceMin());
+        $this->assertSame(0, $response->getPriceMax());
+    }
+
+    private function makeProduct(string $id, string $name, string $brandId, string $categoryId, int $price): Product
+    {
+        return new Product(
+            new ProductId($id),
+            $name,
+            $brandId,
+            $categoryId,
+            new Price($price, 'USD'),
+            'https://example.com/' . $id . '.jpg',
+            'Summary for ' . $name
+        );
+    }
+}

--- a/backend/tests/Unit/Catalog/Domain/ValueObjects/PriceTest.php
+++ b/backend/tests/Unit/Catalog/Domain/ValueObjects/PriceTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Catalog\Domain\ValueObjects;
+
+use Catalog\Domain\ValueObjects\Price;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class PriceTest extends TestCase
+{
+    public function testConstructorStoresAmountAndCurrency(): void
+    {
+        $price = new Price(1999, 'USD');
+        $this->assertSame(1999, $price->getAmount());
+        $this->assertSame('USD', $price->getCurrency());
+    }
+
+    public function testConstructorNormalizesCurrencyToUppercase(): void
+    {
+        $price = new Price(1000, 'usd');
+        $this->assertSame('USD', $price->getCurrency());
+    }
+
+    public function testConstructorRejectsNegativeAmount(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new Price(-1, 'USD');
+    }
+
+    public function testConstructorRejectsNonIso4217Currency(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new Price(100, 'DOLLAR');
+    }
+
+    public function testConstructorRejectsEmptyCurrency(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new Price(100, '');
+    }
+
+    public function testFormatForUsdUsesDollarSign(): void
+    {
+        $price = new Price(1999, 'USD');
+        $this->assertSame('$19.99', $price->format());
+    }
+
+    public function testFormatPadsMinorUnitsToTwoDigits(): void
+    {
+        $price = new Price(1005, 'USD');
+        $this->assertSame('$10.05', $price->format());
+    }
+
+    public function testFormatForZeroAmount(): void
+    {
+        $price = new Price(0, 'USD');
+        $this->assertSame('$0.00', $price->format());
+    }
+
+    public function testFormatForNonUsdPrefixesCurrencyCode(): void
+    {
+        $price = new Price(1999, 'EUR');
+        $this->assertSame('EUR 19.99', $price->format());
+    }
+
+    public function testEqualsReturnsTrueForSameAmountAndCurrency(): void
+    {
+        $a = new Price(1500, 'USD');
+        $b = new Price(1500, 'USD');
+        $this->assertTrue($a->equals($b));
+    }
+
+    public function testEqualsReturnsFalseForDifferentAmount(): void
+    {
+        $a = new Price(1500, 'USD');
+        $b = new Price(1501, 'USD');
+        $this->assertFalse($a->equals($b));
+    }
+
+    public function testEqualsReturnsFalseForDifferentCurrency(): void
+    {
+        $a = new Price(1500, 'USD');
+        $b = new Price(1500, 'EUR');
+        $this->assertFalse($a->equals($b));
+    }
+}

--- a/backend/tests/Unit/Catalog/Infrastructure/Repository/InMemoryProductRepositoryTest.php
+++ b/backend/tests/Unit/Catalog/Infrastructure/Repository/InMemoryProductRepositoryTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Catalog\Infrastructure\Repository;
+
+use Catalog\Application\ReadModel\SearchFilters;
+use Catalog\Domain\Product;
+use Catalog\Infrastructure\Repository\InMemoryProductRepository;
+use PHPUnit\Framework\TestCase;
+
+class InMemoryProductRepositoryTest extends TestCase
+{
+    public function testNoFiltersReturnsAllProductsPaginated(): void
+    {
+        $repo = new InMemoryProductRepository();
+
+        $result = $repo->findByFilters(new SearchFilters(), 1, 12);
+
+        $this->assertSame(20, $result['total']);
+        $this->assertCount(12, $result['products']);
+    }
+
+    public function testResultsAreSortedAlphabeticallyByName(): void
+    {
+        $repo = new InMemoryProductRepository();
+
+        $result = $repo->findByFilters(new SearchFilters(), 1, 100);
+        $names = array_map(static fn (Product $p): string => $p->getName(), $result['products']);
+        $sorted = $names;
+        sort($sorted);
+
+        $this->assertSame($sorted, $names);
+    }
+
+    public function testFilterByCategoryReturnsOnlyMatchingProducts(): void
+    {
+        $repo = new InMemoryProductRepository();
+
+        $result = $repo->findByFilters(new SearchFilters(['cat-books']), 1, 100);
+
+        $this->assertSame(3, $result['total']);
+        foreach ($result['products'] as $product) {
+            $this->assertSame('cat-books', $product->getCategoryId());
+        }
+    }
+
+    public function testFilterByBrandReturnsOnlyMatchingProducts(): void
+    {
+        $repo = new InMemoryProductRepository();
+
+        $result = $repo->findByFilters(new SearchFilters([], ['brand-acme']), 1, 100);
+
+        $this->assertGreaterThan(0, $result['total']);
+        foreach ($result['products'] as $product) {
+            $this->assertSame('brand-acme', $product->getBrandId());
+        }
+    }
+
+    public function testFilterByPriceRangeIsInclusive(): void
+    {
+        $repo = new InMemoryProductRepository();
+
+        $result = $repo->findByFilters(new SearchFilters([], [], 2999, 4999), 1, 100);
+
+        $this->assertGreaterThan(0, $result['total']);
+        foreach ($result['products'] as $product) {
+            $amount = $product->getPrice()->getAmount();
+            $this->assertGreaterThanOrEqual(2999, $amount);
+            $this->assertLessThanOrEqual(4999, $amount);
+        }
+    }
+
+    public function testFilterBySearchTermIsCaseInsensitive(): void
+    {
+        $repo = new InMemoryProductRepository();
+
+        $result = $repo->findByFilters(new SearchFilters([], [], null, null, 'KEYBOARD'), 1, 100);
+
+        $this->assertSame(1, $result['total']);
+        $this->assertSame('Mechanical Keyboard', $result['products'][0]->getName());
+    }
+
+    public function testMultipleFiltersCombineAsAnd(): void
+    {
+        $repo = new InMemoryProductRepository();
+
+        $result = $repo->findByFilters(
+            new SearchFilters(['cat-electronics'], ['brand-globex']),
+            1,
+            100
+        );
+
+        $this->assertGreaterThan(0, $result['total']);
+        foreach ($result['products'] as $product) {
+            $this->assertSame('cat-electronics', $product->getCategoryId());
+            $this->assertSame('brand-globex', $product->getBrandId());
+        }
+    }
+
+    public function testPaginationSlicesResults(): void
+    {
+        $repo = new InMemoryProductRepository();
+
+        $page1 = $repo->findByFilters(new SearchFilters(), 1, 5);
+        $page2 = $repo->findByFilters(new SearchFilters(), 2, 5);
+
+        $this->assertCount(5, $page1['products']);
+        $this->assertCount(5, $page2['products']);
+        $this->assertNotEquals(
+            $page1['products'][0]->getId()->toString(),
+            $page2['products'][0]->getId()->toString()
+        );
+    }
+
+    public function testPageBeyondTotalReturnsEmptyButPreservesTotal(): void
+    {
+        $repo = new InMemoryProductRepository();
+
+        $result = $repo->findByFilters(new SearchFilters(), 99, 12);
+
+        $this->assertSame([], $result['products']);
+        $this->assertSame(20, $result['total']);
+    }
+
+    public function testEmptyResultForUnmatchedFilter(): void
+    {
+        $repo = new InMemoryProductRepository();
+
+        $result = $repo->findByFilters(new SearchFilters(['cat-nonexistent']), 1, 12);
+
+        $this->assertSame([], $result['products']);
+        $this->assertSame(0, $result['total']);
+    }
+
+    public function testFacetsReturnSeededCategoriesAndBrands(): void
+    {
+        $repo = new InMemoryProductRepository();
+
+        $facets = $repo->getFacets();
+
+        $this->assertCount(5, $facets['categories']);
+        $this->assertCount(6, $facets['brands']);
+    }
+
+    public function testFacetsPriceRangeReflectsSeededData(): void
+    {
+        $repo = new InMemoryProductRepository();
+
+        $facets = $repo->getFacets();
+
+        $this->assertSame(1499, $facets['priceMin']);
+        $this->assertSame(29999, $facets['priceMax']);
+    }
+}

--- a/docs/adr/008-security-module.md
+++ b/docs/adr/008-security-module.md
@@ -38,7 +38,7 @@ A two-bus split (one secured bus, one public bus) was considered and rejected. M
 
 ### Per-Audience Configs Composed via Registry
 
-Each audience owns a `SecurityConfigInterface` implementation declaring its commands, queries, and roles. Audiences live under `backend/src/Audience/` (`Audience\Admin\…`, `Audience\Partner\…`, future `Audience\Customer\…`). Configs are composed at DI wiring time via a `SecurityConfigRegistryInterface` (mirrors `CommandHandlerRegistryInterface` from ADR-006). A `CompositeSecurityConfig` merges entries; duplicate command/query keys throw at first lookup; role permissions union and de-duplicate.
+Each audience owns a `SecurityConfigInterface` implementation declaring its commands, queries, and roles. Audiences live under `backend/src/Audience/` (`Audience\Admin\…`, `Audience\Partner\…`, public `Audience\Site\…`). Configs are composed at DI wiring time via a `SecurityConfigRegistryInterface` (mirrors `CommandHandlerRegistryInterface` from ADR-006). A `CompositeSecurityConfig` merges entries; duplicate command/query keys throw at first lookup; role permissions union and de-duplicate.
 
 Bounded contexts (`backend/src/Crm/`, `backend/src/Marketing/`) own **only domain code** — aggregates, domain events, repositories interfaces. They contribute nothing to security configs. Commands and queries live in audiences and operate on bounded-context aggregates by calling their domain methods. The same conceptual operation (e.g., creating a lead) typically has separate command classes per audience — `Audience\Admin\…\CreateLeadCommand` vs `Audience\Partner\…\CreateLeadCommand` — because the surrounding concerns differ (history records, originator stamping, additional validations).
 
@@ -193,5 +193,5 @@ These are real questions raised during design that were intentionally not resolv
 
 - `CognitoJwtUserResolver` for admin panel when admin module lands in production.
 - Laravel `UserResolverInterface` implementation when the Laravel layer reaches authenticated CQRS calls.
-- Customer audience security config (currently only Admin and Partner are wired).
+- Authenticated routes inside the Site audience (cart, profile) — currently only the public read queries are wired; cart/profile permissions land when those features ship.
 - Per-instance policy extension point if/when contextual checks become necessary. The decorator can resolve an optional `PolicyResolverInterface` per command FQCN and invoke `$policy->check($user, $command)` after permission passes — no breaking changes required.

--- a/docs/adr/011-audience-bff-with-service-style-bc-api.md
+++ b/docs/adr/011-audience-bff-with-service-style-bc-api.md
@@ -1,0 +1,128 @@
+# ADR-011: Audience as BFF; Bounded-Context Public API is Service-Style
+
+**Status:** Accepted
+**Date:** 2026-05-16
+
+## Context
+
+ADR-006 introduced a CQRS message bus with decorator chain (Throttle → Security → Logger → Transaction → Handler). ADR-008 established that **audiences** (`Audience/Admin/`, `Audience/Partner/`, public `Audience/Site/`) own their commands, queries, and roles, while **bounded contexts** (`Catalog/`, future `Crm/`, `Marketing/`) own only the domain layer.
+
+The first feature exercising the full chain on a public, anonymous request path (shop home page) raised three questions those ADRs left implicit:
+
+1. What is the public API of a bounded context — CQRS message classes, service methods, or both?
+2. Where do read-side queries live when there is no audience yet? The catalog initially placed them in `Catalog/Application/Query/…` for lack of an `Audience/Site/`.
+3. When a controller needs two pieces of data for one page, dispatch two queries (two decorator chain passes) or compose them into one?
+
+A read-side query handler invoked directly as a function (`($handler)($query)`) is indistinguishable from a method call on a service, but the surrounding ceremony (query class, response class, handler class, registry entry, security config entry, tests) is substantial. When the bus is not actually used, the ceremony is overhead. And two dispatches per request run throttle/security/logger/transaction twice — one can fail while the other passes, leaving half-rendered pages and split log lines.
+
+## Decision
+
+### Bounded-Context Public API is a Service, Not Messages
+
+Each bounded context exposes its application-layer functionality through one or more **application services** with typed methods:
+
+```
+backend/src/Catalog/
+  Domain/                                  (aggregates, value objects, repository interfaces)
+  Application/
+    Service/CatalogReadService.php         ← the BC public API
+    ReadModel/                             ← DTO shapes the service returns
+      SearchFilters.php
+      ProductListItem.php
+      ProductSearchResult.php
+      FilterFacets.php
+  Infrastructure/                          (repository implementations, framework adapters)
+```
+
+Service methods are typed (`searchProducts(SearchFilters, int, int): ProductSearchResult`), synchronous, and called directly by their consumers. They are **not** dispatched through the CQRS bus and **do not** have associated query/handler/response classes inside the BC.
+
+`Application/ReadModel/` holds the data shapes the service hands back. These are flat DTOs designed to be safe to pass to a view layer (no domain objects leak through). When a result is `implements QueryResponseInterface`, that is a convenience for the audience-side handler that wraps it; the BC itself does not depend on the CQRS interfaces.
+
+A version of this with `Catalog\Application\Query\…` classes was tried first — each read operation having `*Query` + `*Handler` + `*Response` + bus registration. It was working but never used through the bus: the Site audience always invoked handlers as `($handler)($query)` because no decorators were wanted at the BC boundary. We removed the bus apparatus from the BC entirely; the service was already the contract.
+
+### Audiences are the BFF; CQRS Messages Exist Because the Bus Exists
+
+Audiences (`Audience/Site/`, `Audience/Admin/`, `Audience/Partner/`) own:
+
+- **CQRS messages** — `*Query`, `*Command`, `*Response` classes that go through the bus. They exist *because* the audience wants the bus decorators (throttle, security, logger, transaction).
+- **HTTP-input parsing** — query classes declare `static fromHttpInput(array $raw): self`. Controllers do `Query::fromHttpInput(Input::get())` and never touch `$_GET` shapes themselves. Strict-typed constructors stay available for programmatic callers (tests, future internal code).
+- **Permission registry** — `*SecurityConfig` lives in the audience, listing the audience's queries/commands with their permissions (per ADR-008's fail-closed model).
+- **Composition** — when a page needs more than one piece of data, the audience defines a **composite query** that returns one response wrapping the parts (`ViewCatalogHomePageResponse` = `ProductSearchResult` + `FilterFacets`).
+
+The audience handler delegates to BC services by direct method call:
+
+```php
+final class ViewCatalogHomePageQueryHandler implements QueryHandlerInterface
+{
+    public function __construct(private CatalogReadService $catalog) {}
+
+    public function __invoke(ViewCatalogHomePageQuery $query): ViewCatalogHomePageResponse
+    {
+        $products = $this->catalog->searchProducts(
+            $query->getFilters(), $query->getPage(), $query->getPerPage()
+        );
+        $facets = $this->catalog->getFilterFacets();
+        return new ViewCatalogHomePageResponse($products, $facets);
+    }
+}
+```
+
+One `$bus->dispatch($compositeQuery)` per page-render: one throttle check, one security check, one log line, one transaction boundary, one atomic decision. The composite-query pattern is the canonical answer to "controller needs multiple BC reads".
+
+### Audience Always Returns Its Own `*Response` Type
+
+Audience query handlers never return BC read models directly, even when the audience response is a near-passthrough:
+
+```php
+public function __invoke(SearchCatalogProductsQuery $query): SearchCatalogProductsResponse
+{
+    $result = $this->catalog->searchProducts(...);   // ProductSearchResult (BC)
+    return new SearchCatalogProductsResponse($result);   // audience-owned wrapper
+}
+```
+
+The audience contract stays stable when the BC evolves. If `ProductSearchResult` gets renamed, splits, or gains/loses fields, callers of `SearchCatalogProductsResponse` see only the audience-shape, and the wrapper's adapter glue absorbs the change. This is a thin Anti-Corruption Layer in the Vernon sense — one-to-one passthrough today, room for audience-specific concerns (cache hints, pagination flags, presentation metadata) tomorrow without churning the BC.
+
+Returning the BC read model directly was tried, scoped to "passthrough cases only". It produced an inconsistency — composite handlers obviously had to wrap, simple-delegate handlers did not — that was easy to learn wrong. Always-wrap removes the rule from the daily decision space.
+
+### BC Queries Are Not Reachable Through the Bus (Fail-Closed)
+
+`Catalog\Application\Service\CatalogReadService` is the only way for an audience to read from the catalog. There is no `Catalog\Application\Query\*` directory, no `CatalogQueryHandlerRegistry` (it was deleted), no entries in any `SecurityConfig` for catalog operations. If something tries `$bus->dispatch(new <hypothetical Catalog query>)`, the security decorator throws `SecurityConfigurationException` — the fail-closed property from ADR-008 keeps the boundary honest.
+
+Inside the BC, the service has whatever signature it likes. Inside an audience, the contract is the audience query/response. The bus only sees audience messages.
+
+## Components
+
+Reference implementation lives under `backend/src/Catalog/` (service + read models, no bus apparatus inside the BC) and `backend/src/Audience/Site/` (composite + single-purpose queries with `fromHttpInput`, a `QueryHandlerRegistry`, a `SecurityConfig` mapping both queries to `null` for public access per ADR-008).
+
+Controller is two lines of meaningful work — parse HTTP input into a typed query, dispatch:
+
+```php
+$query = ViewCatalogHomePageQuery::fromHttpInput(Input::get());
+$page = $this->bus->dispatch($query);
+```
+
+Rendering belongs to ADR-012.
+
+## Consequences
+
+**Positive:**
+
+- BC public API is a method-call surface, not a message catalogue. New contributors discover the BC by reading one service class, not by spelunking through query directories.
+- BC tests are method-level: `$service->searchProducts(...)` returns a result; no bus/decorator scaffolding in unit tests.
+- Audience CQRS overhead is justified by what it gives — one bus dispatch produces one decorator pass, one log, one throttle check. Multiple BC operations per page run inside one composite handler at near method-call cost.
+- Audience contract stability decoupled from BC evolution. The catalog can rename `ProductSearchResult` to `Catalog\Application\ReadModel\ProductPage` without touching `Audience\Site\Application\Query\SearchCatalogProducts\SearchCatalogProductsResponse`.
+- Fail-closed property from ADR-008 actively enforces the boundary: any accidental attempt to dispatch a BC query through the bus throws at dispatch time, not at deploy time.
+- Migration target Laravel maps cleanly: BC services become Laravel singletons, audience queries become Laravel-side commands/queries handled by a similar bus or direct `Bus::dispatch`. The structural distinction survives the framework switch.
+
+**Negative:**
+
+- Doubled DTO surface for audiences whose contract is identical to the BC's. `SearchCatalogProductsResponse { private ProductSearchResult $result; }` is mostly ceremony today. The cost is small (≤30 lines per audience-query) and pays back the first time a BC shape changes; the discipline of always-wrap is worth keeping.
+- Audience handlers couple to BC service implementations (constructor takes the service class). If a service is later split or renamed, all dependent audience handlers update their wiring. This is acceptable — service surface is the BC's stable contract; if it changes, dependents need to know.
+- Composite handlers can grow when a page needs many small reads. The intent is to keep composites at the audience level; if multiple audiences need the same composition, that's a signal to add a method on the BC service rather than duplicate the composition in two audiences.
+
+**Migrations and follow-ups:**
+
+- When `Audience/Partner/` gets write-side commands (e.g., `RegisterProductCommand`), they live there, dispatched through the same bus with throttle/security/transaction, and they call into `Catalog\Application\Service\CatalogWriteService` (to be created when there is one). The pattern is symmetric for the write side.
+- When Marketing or CRM contexts are populated, they follow the same shape: `Application/Service/*Service.php`, `Application/ReadModel/*`, no bus apparatus inside the BC.
+- ADR-008's existing rule "audiences own commands, queries, and roles" is reinforced by this ADR. Treat them as one decision set.

--- a/frontend/src/site/core.css
+++ b/frontend/src/site/core.css
@@ -1,3 +1,42 @@
 :root {
-    /* design tokens go here */
+    --bg: #ffffff;
+    --bg-muted: #f3f3f3;
+    --bg-elevated: #ffffff;
+    --fg: #111111;
+    --fg-muted: #555555;
+    --border: #d5d9d9;
+    --border-strong: #888c8c;
+    --accent: #232f3e;
+    --accent-fg: #ffffff;
+    --link: #007185;
+    --link-hover: #c7511f;
+    --price: #0f1111;
+    --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.06);
+    --radius: 4px;
+    --max-width: 1400px;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html,
+body {
+    margin: 0;
+    padding: 0;
+    background: var(--bg-muted);
+    color: var(--fg);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, sans-serif;
+    font-size: 14px;
+    line-height: 1.45;
+}
+
+a {
+    color: var(--link);
+    text-decoration: none;
+}
+
+a:hover {
+    color: var(--link-hover);
+    text-decoration: underline;
 }

--- a/frontend/src/site/pages/search.css
+++ b/frontend/src/site/pages/search.css
@@ -1,1 +1,332 @@
-/* search page styles */
+/* Header */
+.site-header {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 10px 20px;
+    background: var(--accent);
+    color: var(--accent-fg);
+}
+
+.site-logo {
+    font-size: 22px;
+    font-weight: 700;
+    color: var(--accent-fg);
+    flex-shrink: 0;
+}
+
+.site-logo:hover {
+    color: var(--accent-fg);
+    text-decoration: none;
+}
+
+.site-search {
+    flex: 1;
+    display: flex;
+    max-width: 800px;
+}
+
+.site-search input[type="search"] {
+    flex: 1;
+    height: 38px;
+    padding: 0 12px;
+    border: none;
+    border-radius: var(--radius) 0 0 var(--radius);
+    font-size: 15px;
+    background: var(--bg);
+    color: var(--fg);
+}
+
+.site-search button {
+    height: 38px;
+    padding: 0 16px;
+    border: none;
+    border-radius: 0 var(--radius) var(--radius) 0;
+    background: #febd69;
+    cursor: pointer;
+    font-weight: 600;
+    color: var(--fg);
+}
+
+.site-search button:hover {
+    background: #f3a847;
+}
+
+.site-nav {
+    display: flex;
+    gap: 8px;
+    flex-shrink: 0;
+}
+
+.btn {
+    display: inline-block;
+    padding: 8px 16px;
+    border-radius: var(--radius);
+    font-weight: 600;
+    cursor: pointer;
+    border: 1px solid transparent;
+    text-decoration: none;
+    font-size: 13px;
+}
+
+.btn:hover {
+    text-decoration: none;
+}
+
+.btn-primary {
+    background: #febd69;
+    color: var(--fg);
+    border-color: #febd69;
+}
+
+.btn-primary:hover {
+    background: #f3a847;
+    color: var(--fg);
+}
+
+.btn-secondary {
+    background: transparent;
+    color: var(--accent-fg);
+    border-color: var(--accent-fg);
+}
+
+.btn-secondary:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: var(--accent-fg);
+}
+
+/* Two-column layout */
+.site-main {
+    max-width: var(--max-width);
+    margin: 0 auto;
+    padding: 20px;
+}
+
+.catalog-layout {
+    display: grid;
+    grid-template-columns: 240px 1fr;
+    gap: 24px;
+    align-items: start;
+}
+
+@media (max-width: 768px) {
+    .catalog-layout {
+        grid-template-columns: 1fr;
+    }
+}
+
+/* Filters */
+.catalog-filters {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 16px;
+    position: sticky;
+    top: 16px;
+}
+
+.filters {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    margin: 0;
+}
+
+.filter-group {
+    border: none;
+    margin: 0;
+    padding: 0;
+}
+
+.filter-group legend {
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--fg);
+    margin-bottom: 8px;
+    padding: 0;
+}
+
+.filter-option {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 0;
+    font-size: 13px;
+    color: var(--fg-muted);
+    cursor: pointer;
+}
+
+.filter-option:hover {
+    color: var(--fg);
+}
+
+.filter-option input[type="checkbox"] {
+    margin: 0;
+    cursor: pointer;
+}
+
+.price-input {
+    width: 100%;
+    height: 32px;
+    padding: 0 10px;
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius);
+    font-size: 13px;
+    background: var(--bg);
+    color: var(--fg);
+    margin-bottom: 8px;
+}
+
+.price-input:focus {
+    outline: none;
+    border-color: var(--link);
+    box-shadow: 0 0 0 2px rgba(0, 113, 133, 0.2);
+}
+
+/* Grid */
+.catalog-content {
+    min-width: 0;
+}
+
+.grid-header {
+    margin: 0 0 16px 0;
+    padding: 8px 4px;
+    color: var(--fg-muted);
+    font-size: 13px;
+}
+
+.grid-header p {
+    margin: 0;
+}
+
+.grid-empty {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 40px;
+    text-align: center;
+    color: var(--fg-muted);
+}
+
+.product-grid {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 16px;
+}
+
+.product-card {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    transition: box-shadow 120ms ease, transform 120ms ease;
+}
+
+.product-card:hover {
+    box-shadow: var(--shadow-card);
+    transform: translateY(-1px);
+}
+
+.product-card-link {
+    display: block;
+    color: var(--fg);
+    padding: 12px;
+}
+
+.product-card-link:hover {
+    color: var(--fg);
+    text-decoration: none;
+}
+
+.product-card-image {
+    display: block;
+    width: 100%;
+    height: auto;
+    aspect-ratio: 1 / 1;
+    object-fit: cover;
+    border-radius: var(--radius);
+    background: var(--bg-muted);
+    margin-bottom: 10px;
+}
+
+.product-card-name {
+    font-size: 14px;
+    font-weight: 500;
+    margin: 0 0 4px 0;
+    line-height: 1.3;
+    color: var(--fg);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.product-card-link:hover .product-card-name {
+    color: var(--link-hover);
+}
+
+.product-card-brand {
+    font-size: 12px;
+    color: var(--fg-muted);
+    margin: 0 0 6px 0;
+}
+
+.product-card-price {
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--price);
+    margin: 4px 0 0 0;
+}
+
+/* Pagination */
+.pagination {
+    display: flex;
+    gap: 4px;
+    justify-content: center;
+    margin: 24px 0 8px 0;
+    flex-wrap: wrap;
+}
+
+.pagination-link {
+    min-width: 36px;
+    height: 36px;
+    padding: 0 10px;
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius);
+    background: var(--bg-elevated);
+    color: var(--link);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 13px;
+    font-weight: 500;
+}
+
+.pagination-link:hover {
+    background: var(--bg-muted);
+    text-decoration: none;
+}
+
+.pagination-link.is-active {
+    background: var(--accent);
+    color: var(--accent-fg);
+    border-color: var(--accent);
+    pointer-events: none;
+}
+
+/* Footer */
+.site-footer {
+    max-width: var(--max-width);
+    margin: 40px auto 0;
+    padding: 16px 20px;
+    text-align: center;
+    color: var(--fg-muted);
+    font-size: 12px;
+    border-top: 1px solid var(--border);
+}
+
+.site-footer p {
+    margin: 0;
+}

--- a/fuelphp/fuel/app/classes/controller/site/home.php
+++ b/fuelphp/fuel/app/classes/controller/site/home.php
@@ -1,0 +1,42 @@
+<?php
+
+use Audience\Site\Application\Query\SearchCatalogProducts\SearchCatalogProductsQuery;
+use Audience\Site\Application\Query\ViewCatalogHomePage\ViewCatalogHomePageQuery;
+use Fuel\Core\Input;
+
+class Controller_Site_Home extends Controller_Site_Abstract
+{
+    public function action_index()
+    {
+        $query = ViewCatalogHomePageQuery::fromHttpInput(Input::get());
+        $page = $this->bus->dispatch($query);
+
+        return Blade::respond('site.home.index', [
+            'title' => 'Shop',
+            'products' => $page->getProducts(),
+            'facets' => $page->getFacets(),
+            'filters' => $query->getFilters(),
+        ]);
+    }
+
+    public function action_products()
+    {
+        if (Input::headers('HX-Request') !== 'true') {
+            $qs = Input::server('QUERY_STRING', '');
+            return \Fuel\Core\Response::redirect('/' . ($qs !== '' ? '?' . $qs : ''));
+        }
+
+        $query = SearchCatalogProductsQuery::fromHttpInput(Input::get());
+        $response = $this->bus->dispatch($query);
+
+        $pushQuery = http_build_query(array_merge($query->getFilters()->toArray(), [
+            'page' => $query->getPage(),
+        ]));
+        $pushUrl = '/' . ($pushQuery !== '' ? '?' . $pushQuery : '');
+
+        return Blade::respond('site.home._grid', [
+            'products' => $response->getResult(),
+            'filters' => $query->getFilters(),
+        ], 200, ['HX-Push-Url' => $pushUrl]);
+    }
+}

--- a/fuelphp/fuel/app/config/di.php
+++ b/fuelphp/fuel/app/config/di.php
@@ -1,6 +1,8 @@
 <?php
 
 use Audience\Admin\Infrastructure\Security\AdminSecurityConfigRegistry;
+use Audience\Site\Infrastructure\CqrsMessageBus\SiteQueryHandlerRegistry;
+use Audience\Site\Infrastructure\Security\SiteSecurityConfigRegistry;
 use Audience\Partner\Infrastructure\Security\PartnerSecurityConfigRegistry;
 use DI\ContainerBuilder;
 use Fuel\Core\Fuel;
@@ -89,12 +91,13 @@ $containerBuilder->addDefinitions(array_merge([
     UserResolverInterface::class => DI\autowire(FuelPhpAuthUserResolver::class),
 
     // Security Config — composed from SharedKernel + per-audience registries.
-    // Bounded contexts (Crm, Marketing) own only domain. Audiences (Admin, Partner, Customer)
+    // Bounded contexts (Crm, Marketing) own only domain. Audiences (Admin, Partner, Site)
     // own their commands, queries, and roles. Add new audience registries here.
     SecurityConfigInterface::class => DI\factory(function (ContainerInterface $c) {
         $factory = new SecurityConfigFactory([
             $c->get(AdminSecurityConfigRegistry::class),
             $c->get(PartnerSecurityConfigRegistry::class),
+            $c->get(SiteSecurityConfigRegistry::class),
         ]);
         return $factory();
     }),
@@ -141,9 +144,7 @@ $containerBuilder->addDefinitions(array_merge([
     // Decorator chain (outermost → innermost): Throttle → Security → Logger → Handler
     QueryBusInterface::class => DI\factory(function (ContainerInterface $c) {
         $bus = (new QueryBusFactory($c, [
-            // Add bounded-context registries here:
-            // new CrmQueryHandlerRegistry(),
-            // new MarketingQueryHandlerRegistry(),
+            new SiteQueryHandlerRegistry(),
         ]))();
         $bus = new QueryLoggerDecorator($bus, $c->get(LoggerInterface::class));
         $bus = new SecurityQueryDecorator(

--- a/fuelphp/fuel/app/config/repositories.php
+++ b/fuelphp/fuel/app/config/repositories.php
@@ -1,3 +1,8 @@
 <?php
 
-return [];
+use Catalog\Domain\Repository\ProductRepositoryInterface;
+use Catalog\Infrastructure\Repository\InMemoryProductRepository;
+
+return [
+    ProductRepositoryInterface::class => DI\autowire(InMemoryProductRepository::class),
+];

--- a/fuelphp/fuel/app/config/routes.php
+++ b/fuelphp/fuel/app/config/routes.php
@@ -20,7 +20,8 @@ return array(
 	 *
 	 */
 
-	'_root_' => 'welcome/index',
+	'_root_' => 'site/home/index',
+    'products' => 'site/home/products',
     'admin' => 'admin/welcome/index',
     'partner' => 'partner/welcome/index',
     'healthcheck' => function () { return Response::forge('healthy'); },

--- a/fuelphp/fuel/app/views/site/home/_card.blade.php
+++ b/fuelphp/fuel/app/views/site/home/_card.blade.php
@@ -1,0 +1,14 @@
+@php /** @var \Catalog\Application\ReadModel\ProductListItem $p */ @endphp
+<li class="product-card">
+    <a href="/products/{{ $p->getId() }}" class="product-card-link">
+        <img class="product-card-image"
+             src="{{ $p->getImageUrl() }}"
+             alt=""
+             loading="lazy"
+             width="200"
+             height="200">
+        <h3 class="product-card-name">{{ $p->getName() }}</h3>
+        <p class="product-card-brand">{{ $p->getBrandName() }}</p>
+        <p class="product-card-price">{{ $p->getPriceFormatted() }}</p>
+    </a>
+</li>

--- a/fuelphp/fuel/app/views/site/home/_filters.blade.php
+++ b/fuelphp/fuel/app/views/site/home/_filters.blade.php
@@ -1,0 +1,69 @@
+@php
+    /** @var \Catalog\Application\ReadModel\FilterFacets $facets */
+    /** @var \Catalog\Application\ReadModel\SearchFilters $filters */
+    $selectedCategories = $filters->getCategoryIds();
+    $selectedBrands = $filters->getBrandIds();
+    $priceMin = $filters->getPriceMin();
+    $priceMax = $filters->getPriceMax();
+    $q = $filters->getSearchTerm();
+@endphp
+<form class="filters"
+      action="/"
+      method="get"
+      hx-get="/products"
+      hx-target="#product-grid"
+      hx-swap="innerHTML"
+      hx-trigger="change, input changed delay:400ms from:.price-input">
+
+    @if ($q !== null)
+        <input type="hidden" name="q" value="{{ $q }}">
+    @endif
+
+    <fieldset class="filter-group">
+        <legend>Category</legend>
+        @foreach ($facets->getCategories() as $category)
+            <label class="filter-option">
+                <input type="checkbox"
+                       name="category[]"
+                       value="{{ $category->getId() }}"
+                       {{ in_array($category->getId(), $selectedCategories, true) ? 'checked' : '' }}>
+                {{ $category->getName() }}
+            </label>
+        @endforeach
+    </fieldset>
+
+    <fieldset class="filter-group">
+        <legend>Brand</legend>
+        @foreach ($facets->getBrands() as $brand)
+            <label class="filter-option">
+                <input type="checkbox"
+                       name="brand[]"
+                       value="{{ $brand->getId() }}"
+                       {{ in_array($brand->getId(), $selectedBrands, true) ? 'checked' : '' }}>
+                {{ $brand->getName() }}
+            </label>
+        @endforeach
+    </fieldset>
+
+    <fieldset class="filter-group">
+        <legend>Price (cents)</legend>
+        <input class="price-input"
+               type="number"
+               name="price_min"
+               min="{{ $facets->getPriceMin() }}"
+               max="{{ $facets->getPriceMax() }}"
+               placeholder="from"
+               value="{{ $priceMin !== null ? (int) $priceMin : '' }}">
+        <input class="price-input"
+               type="number"
+               name="price_max"
+               min="{{ $facets->getPriceMin() }}"
+               max="{{ $facets->getPriceMax() }}"
+               placeholder="to"
+               value="{{ $priceMax !== null ? (int) $priceMax : '' }}">
+    </fieldset>
+
+    <noscript>
+        <button type="submit" class="btn btn-primary">Apply filters</button>
+    </noscript>
+</form>

--- a/fuelphp/fuel/app/views/site/home/_grid.blade.php
+++ b/fuelphp/fuel/app/views/site/home/_grid.blade.php
@@ -1,0 +1,34 @@
+@php
+    /** @var \Catalog\Application\ReadModel\ProductSearchResult $products */
+    /** @var \Catalog\Application\ReadModel\SearchFilters $filters */
+    $total = $products->getTotal();
+    $currentPage = $products->getPage();
+    $totalPages = $products->getTotalPages();
+    $filterQuery = $filters->toArray();
+@endphp
+<div class="grid-header">
+    <p>Found <strong>{{ $total }}</strong> item{{ $total === 1 ? '' : 's' }}</p>
+</div>
+
+@if (count($products->getItems()) === 0)
+    <p class="grid-empty">No products match the selected filters.</p>
+@else
+    <ul class="product-grid">
+        @foreach ($products->getItems() as $item)
+            @include('site.home._card', ['p' => $item])
+        @endforeach
+    </ul>
+@endif
+
+@if ($totalPages > 1)
+    <nav class="pagination" aria-label="Pagination">
+        @for ($i = 1; $i <= $totalPages; $i++)
+            @php $query = array_merge($filterQuery, ['page' => $i]); @endphp
+            <a href="/?{{ http_build_query($query) }}"
+               hx-get="/products?{{ http_build_query($query) }}"
+               hx-target="#product-grid"
+               hx-swap="innerHTML"
+               class="pagination-link {{ $i === $currentPage ? 'is-active' : '' }}">{{ $i }}</a>
+        @endfor
+    </nav>
+@endif

--- a/fuelphp/fuel/app/views/site/home/index.blade.php
+++ b/fuelphp/fuel/app/views/site/home/index.blade.php
@@ -1,0 +1,14 @@
+@extends('site.layout')
+
+@section('content')
+<div class="catalog-layout">
+    <aside class="catalog-filters">
+        @include('site.home._filters', ['facets' => $facets, 'filters' => $filters])
+    </aside>
+    <section class="catalog-content">
+        <div id="product-grid">
+            @include('site.home._grid', ['products' => $products, 'filters' => $filters])
+        </div>
+    </section>
+</div>
+@endsection

--- a/fuelphp/fuel/app/views/site/layout.blade.php
+++ b/fuelphp/fuel/app/views/site/layout.blade.php
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ $title ?? 'Shop' }}</title>
+    {!! Vite::asset('src/site/core.js') !!}
+    {!! Vite::asset('src/site/pages/search.js') !!}
+</head>
+<body>
+    @include('site.partials.header')
+    <main class="site-main">
+        @yield('content')
+    </main>
+    @include('site.partials.footer')
+</body>
+</html>

--- a/fuelphp/fuel/app/views/site/partials/footer.blade.php
+++ b/fuelphp/fuel/app/views/site/partials/footer.blade.php
@@ -1,0 +1,3 @@
+<footer class="site-footer">
+    <p>&copy; {{ date('Y') }} Shop prototype</p>
+</footer>

--- a/fuelphp/fuel/app/views/site/partials/header.blade.php
+++ b/fuelphp/fuel/app/views/site/partials/header.blade.php
@@ -1,0 +1,15 @@
+@php
+    $q = \Fuel\Core\Input::get('q');
+    $q = is_string($q) ? $q : '';
+@endphp
+<header class="site-header">
+    <a class="site-logo" href="/">Shop</a>
+    <form class="site-search" action="/" method="get" role="search">
+        <input type="search" name="q" placeholder="Search products…" value="{{ $q }}">
+        <button type="submit">Search</button>
+    </form>
+    <nav class="site-nav">
+        <a class="btn btn-secondary" href="/login">Login</a>
+        <a class="btn btn-primary" href="/register">Register</a>
+    </nav>
+</header>


### PR DESCRIPTION
## What

First feature on the public site path. Catalog browsing page with category/brand/price filters and HTMX-driven partial updates, on a prototype dataset of 20 fake products.

## Architecture

See \`docs/adr/011-audience-bff-with-service-style-bc-api.md\` for the full rationale. Summary:

- \`Catalog/\` bounded context exposes a **method-style** public API:
  - \`Application/Service/CatalogReadService\` — \`searchProducts\`, \`getFilterFacets\`
  - \`Application/ReadModel/{SearchFilters, ProductListItem, ProductSearchResult, FilterFacets}\`
  - \`Domain/\` aggregates + VOs + \`ProductRepositoryInterface\`
  - \`Infrastructure/Repository/InMemoryProductRepository\` — 20 fake products
  - **No CQRS bus apparatus inside the BC.** Catalog operations are method calls, not messages.

- \`Audience/Site/\` owns the CQRS messages that go through the bus:
  - \`ViewCatalogHomePageQuery\` — composite, one dispatch for the full page
  - \`SearchCatalogProductsQuery\` — for the HTMX partial endpoint
  - Both delegate to \`CatalogReadService\` by direct method call.
  - Always wraps BC read models in an audience-owned \`*Response\` (anti-corruption layer).
  - Both queries registered as \`null\` permission (public) in \`SiteSecurityConfig\`.

- \`Controller_Site_Home\` (in \`app/classes/controller/site/home.php\`):
  - \`action_index\` — full page via \`ViewCatalogHomePageQuery\`
  - \`action_products\` — HTMX partial; redirects non-HTMX callers to \`/?...\` and sets \`HX-Push-Url\` so HTMX pushes the user-facing URL into history rather than the partial endpoint

- Blade views under \`app/views/site/{layout, home/*, partials/*}\`. CSS in \`frontend/src/site/{core.css, pages/search.css}\`.

This PR also updates ADR-008 terminology: audience layer is \`Audience/Site/\`, not Customer.

## Test plan

- [x] 56 new unit tests (Catalog domain, service, repository, audience handlers, queries)
- [x] \`make test-unit\` (420 backend + 8 fuelphp app) and \`make lint\` green
- [x] \`/\` -> 200 with catalog grid + filters
- [x] \`/products?category[]=cat-books\` (with \`HX-Request: true\`) -> 200 partial, \"Found 3 items\"
- [x] \`/products?...\` without \`HX-Request\` -> 302 redirect to \`/?...\`
- [x] XSS probe \`?q=<script>\` -> escaped at Blade \`{{ }}\` layer (verified in browser)
- [x] back/forward/refresh work via server-side \`HX-Push-Url\`

## Stacked

Based on #9 (\`refactor/remove-fuelphp-modules\`). Merge after #9.