### PR TITLE
Split RedisMasterClientInterface for strong-consistency reads

### DIFF
--- a/backend/src/SharedKernel/Domain/Redis/RedisClientInterface.php
+++ b/backend/src/SharedKernel/Domain/Redis/RedisClientInterface.php
@@ -100,11 +100,4 @@ interface RedisClientInterface
      * @throws RedisConnectionException
      */
     public function expire(string $key, int $ttl): bool;
-
-    /**
-     * Get value by key from master (write) node only
-     * Use this for operations requiring strong consistency
-     * @throws RedisConnectionException
-     */
-    public function getMaster(string $key): ?string;
 }

--- a/backend/src/SharedKernel/Domain/Redis/RedisMasterClientInterface.php
+++ b/backend/src/SharedKernel/Domain/Redis/RedisMasterClientInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Domain\Redis;
+
+/**
+ * Marker interface for clients that talk directly to the Redis master node.
+ *
+ * Use this type for consumers that need strong-consistency reads — i.e. a
+ * value just written by another request must be visible immediately, with
+ * no replica lag. The canonical example is rate limiting, where a
+ * just-blocked identifier must not slip through via a stale replica.
+ *
+ * Standard cache reads should keep depending on RedisClientInterface and
+ * route through ReadWriteRedisClient.
+ */
+interface RedisMasterClientInterface extends RedisClientInterface
+{
+}

--- a/backend/src/SharedKernel/Infrastructure/Redis/ReadWriteRedisClient.php
+++ b/backend/src/SharedKernel/Infrastructure/Redis/ReadWriteRedisClient.php
@@ -120,11 +120,6 @@ class ReadWriteRedisClient implements RedisClientInterface
         return $this->writeClient->setnx($key, $value, $ttl);
     }
 
-    public function getMaster(string $key): ?string
-    {
-        return $this->writeClient->get($key);
-    }
-
     private function logFailover(string $operation, RedisConnectionException $e): void
     {
         if ($this->logger === null) {

--- a/backend/src/SharedKernel/Infrastructure/Throttle/RedisThrottler.php
+++ b/backend/src/SharedKernel/Infrastructure/Throttle/RedisThrottler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SharedKernel\Infrastructure\Throttle;
 
 use SharedKernel\Domain\Redis\Exceptions\RedisConnectionException;
-use SharedKernel\Domain\Redis\RedisClientInterface;
+use SharedKernel\Domain\Redis\RedisMasterClientInterface;
 use SharedKernel\Domain\Throttle\Exceptions\ThrottleDriverException;
 use SharedKernel\Domain\Throttle\ThrottleConfig;
 use SharedKernel\Domain\Throttle\ThrottleInterface;
@@ -15,11 +15,11 @@ class RedisThrottler implements ThrottleInterface
 {
     private const REDIS_KEY_PREFIX = 'throttle';
 
-    protected RedisClientInterface $redis;
+    protected RedisMasterClientInterface $redis;
     protected ThrottleConfig $config;
     protected string $type;
 
-    public function __construct(RedisClientInterface $redis, ThrottleConfig $config, string $type)
+    public function __construct(RedisMasterClientInterface $redis, ThrottleConfig $config, string $type)
     {
         $this->redis = $redis;
         $this->config = $config;
@@ -92,7 +92,7 @@ class RedisThrottler implements ThrottleInterface
     private function isBlocked(string $identifier): bool
     {
         $blockedKey = self::REDIS_KEY_PREFIX . ":$this->type:$identifier:blocked";
-        $blockedUntil = $this->redis->getMaster($blockedKey);
+        $blockedUntil = $this->redis->get($blockedKey);
 
         return $blockedUntil !== null && (int) $blockedUntil > time();
     }
@@ -100,7 +100,7 @@ class RedisThrottler implements ThrottleInterface
     private function getBlockedUntil(string $identifier): int
     {
         $blockedKey = self::REDIS_KEY_PREFIX . ":$this->type:$identifier:blocked";
-        $blockedUntil = $this->redis->getMaster($blockedKey);
+        $blockedUntil = $this->redis->get($blockedKey);
 
         return $blockedUntil !== null ? (int) $blockedUntil : 0;
     }

--- a/backend/src/SharedKernel/Infrastructure/Throttle/RedisThrottlerFactory.php
+++ b/backend/src/SharedKernel/Infrastructure/Throttle/RedisThrottlerFactory.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace SharedKernel\Infrastructure\Throttle;
 
-use SharedKernel\Domain\Redis\RedisClientInterface;
+use SharedKernel\Domain\Redis\RedisMasterClientInterface;
 use SharedKernel\Domain\Throttle\ThrottleConfig;
 use SharedKernel\Domain\Throttle\ThrottleFactoryInterface;
 use SharedKernel\Domain\Throttle\ThrottleInterface;
 
 final class RedisThrottlerFactory implements ThrottleFactoryInterface
 {
-    private RedisClientInterface $redisClient;
+    private RedisMasterClientInterface $redisClient;
 
-    public function __construct(RedisClientInterface $redisClient)
+    public function __construct(RedisMasterClientInterface $redisClient)
     {
         $this->redisClient = $redisClient;
     }

--- a/backend/src/SharedKernel/Infrastructure/Throttle/ThrottleDriverFactory.php
+++ b/backend/src/SharedKernel/Infrastructure/Throttle/ThrottleDriverFactory.php
@@ -5,15 +5,15 @@ declare(strict_types=1);
 namespace SharedKernel\Infrastructure\Throttle;
 
 use SharedKernel\Domain\Environment;
-use SharedKernel\Domain\Redis\RedisClientInterface;
+use SharedKernel\Domain\Redis\RedisMasterClientInterface;
 use SharedKernel\Domain\Throttle\ThrottleFactoryInterface;
 
 final class ThrottleDriverFactory
 {
     private Environment $environment;
-    private RedisClientInterface $redisClient;
+    private RedisMasterClientInterface $redisClient;
 
-    public function __construct(Environment $environment, RedisClientInterface $redisClient)
+    public function __construct(Environment $environment, RedisMasterClientInterface $redisClient)
     {
         $this->environment = $environment;
         $this->redisClient = $redisClient;

--- a/backend/tests/Unit/SharedKernel/Infrastructure/Redis/ReadWriteRedisClientTest.php
+++ b/backend/tests/Unit/SharedKernel/Infrastructure/Redis/ReadWriteRedisClientTest.php
@@ -152,20 +152,6 @@ class ReadWriteRedisClientTest extends TestCase
         $this->assertTrue($this->client->setnx('lock', '1', 30));
     }
 
-    // --- getMaster always routes to write client ---
-
-    public function testGetMasterRoutesToWriteClient(): void
-    {
-        $this->writeClient->expects($this->once())
-            ->method('get')
-            ->with('key1')
-            ->willReturn('value1');
-
-        $this->readClient->expects($this->never())->method('get');
-
-        $this->assertSame('value1', $this->client->getMaster('key1'));
-    }
-
     // --- Failover from replica to master ---
 
     public function testGetFailsOverToMasterOnReplicaError(): void

--- a/docs/adr/001-redis-client-implementation.md
+++ b/docs/adr/001-redis-client-implementation.md
@@ -77,16 +77,9 @@ Two vocabularies are used deliberately: AWS-facing config uses `primary`/`reader
 
 ### Strong-consistency reads (RedisMasterClientInterface)
 
-Cache reads through `ReadWriteRedisClient` go to the replica and are eventually consistent. A few consumers — rate limiting being the canonical case — need to read a value that may have been written milliseconds earlier by another request, with no replica lag tolerated. Routing such a read through a lagging replica is a real correctness bug (a just-blocked identifier could slip through).
+`ReadWriteRedisClient` routes reads to the replica — eventually consistent. Consumers that need to read a value written milliseconds earlier (rate limiting being the canonical case) depend instead on `RedisMasterClientInterface extends RedisClientInterface`, bound to a master-only client. `PhpRedisClient` implements both; `ReadWriteRedisClient` only the base.
 
-We model this with a marker interface, `RedisMasterClientInterface extends RedisClientInterface`, bound to a master-only client. `PhpRedisClient` implements both; `ReadWriteRedisClient` implements only the base interface. Consumers depend on whichever interface matches their consistency needs.
-
-```
-RedisClientInterface          → ReadWriteRedisClient (cache, eventual consistency)
-RedisMasterClientInterface    → PhpRedisClient (throttler, strong consistency)
-```
-
-`RedisMasterClientFactory` builds the master client from `redis.primary` only — no reader fallback, no failover decorator. If the master is unreachable, strong-consistency callers fail fast; for security-sensitive workloads (rate limiting) that is the correct posture. Both clients share the same `pconnect` persistent-id (`'master'`), so they reuse the same TCP socket per FPM worker — no connection doubling.
+`RedisMasterClientFactory` reads `redis.primary` only — no reader fallback, no failover decorator. For security-sensitive workloads, fail-fast on an unreachable master is the correct posture. Both clients share the same `pconnect` persistent-id (`'master'`) so they reuse the same TCP socket per FPM worker — no connection doubling.
 
 ### Pipeline isn't included
 

--- a/docs/adr/001-redis-client-implementation.md
+++ b/docs/adr/001-redis-client-implementation.md
@@ -49,14 +49,16 @@ This means:
 backend/src/SharedKernel/
   Domain/Redis/
     RedisClientInterface.php          # Contract
+    RedisMasterClientInterface.php    # Marker for strong-consistency reads
     Exceptions/RedisConnectionException.php
   Infrastructure/Redis/
     ReadWriteRedisClient.php          # Routes reads to replica, writes to master
 
 fuelphp/fuel/packages/infrastructure/classes/Redis/
-  PhpRedisClient.php                  # ext-redis implementation
+  PhpRedisClient.php                  # ext-redis impl (both interfaces)
   RedisConfig.php                     # Connection DTO
-  RedisClientFactory.php              # Reads Config::get('redis.*'), builds clients
+  RedisClientFactory.php              # Builds ReadWriteRedisClient
+  RedisMasterClientFactory.php        # Builds master-only client (no failover)
 
 fuelphp/fuel/app/config/redis.php     # primary + reader sections, env-overridable
 ```
@@ -68,6 +70,23 @@ Laravel will mirror this layout: `laravel/app/Infrastructure/Redis/*` + a servic
 `RedisClientFactory` reads from the framework's config (`Config::get('redis.*')` on FuelPHP), not from `getenv()` directly. Defaults live in `app/config/redis.php` in code; env variables only override. This makes per-environment overrides composable (FuelPHP's `app/config/{development,test}/redis.php` cascade) and keeps the factory free of env knowledge. Same pattern as `Blade` (`app/classes/blade.php`).
 
 **Do not delete `db.redis.default` from `fuelphp/fuel/app/config/db.php`** — FuelPHP core (`Session_Redis` via `Redis_Db`) consumes it directly with its own array shape; it is not interchangeable with `redis.php`.
+
+### Terminology: primary/reader vs master/replica
+
+Two vocabularies are used deliberately: AWS-facing config uses `primary`/`reader` (matching ElastiCache endpoint names that ops sees in Terraform/CloudFormation), in-code roles use `master`/`replica` (matching Redis topology terminology). The bridge is `redis.primary.connection_type = 'master'`. Keep the AWS terms at the env/config boundary, the Redis terms in code.
+
+### Strong-consistency reads (RedisMasterClientInterface)
+
+Cache reads through `ReadWriteRedisClient` go to the replica and are eventually consistent. A few consumers — rate limiting being the canonical case — need to read a value that may have been written milliseconds earlier by another request, with no replica lag tolerated. Routing such a read through a lagging replica is a real correctness bug (a just-blocked identifier could slip through).
+
+We model this with a marker interface, `RedisMasterClientInterface extends RedisClientInterface`, bound to a master-only client. `PhpRedisClient` implements both; `ReadWriteRedisClient` implements only the base interface. Consumers depend on whichever interface matches their consistency needs.
+
+```
+RedisClientInterface          → ReadWriteRedisClient (cache, eventual consistency)
+RedisMasterClientInterface    → PhpRedisClient (throttler, strong consistency)
+```
+
+`RedisMasterClientFactory` builds the master client from `redis.primary` only — no reader fallback, no failover decorator. If the master is unreachable, strong-consistency callers fail fast; for security-sensitive workloads (rate limiting) that is the correct posture. Both clients share the same `pconnect` persistent-id (`'master'`), so they reuse the same TCP socket per FPM worker — no connection doubling.
 
 ### Pipeline isn't included
 

--- a/fuelphp/fuel/app/config/di.php
+++ b/fuelphp/fuel/app/config/di.php
@@ -30,6 +30,7 @@ use SharedKernel\Domain\Logger\LoggerInterface;
 use SharedKernel\Domain\Notification\Channel\EmailNotifierInterface;
 use SharedKernel\Domain\Notification\Channel\SmsNotifierInterface;
 use SharedKernel\Domain\Redis\RedisClientInterface;
+use SharedKernel\Domain\Redis\RedisMasterClientInterface;
 use SharedKernel\Domain\Security\AuthorizationServiceInterface;
 use SharedKernel\Domain\Security\SecurityConfigInterface;
 use SharedKernel\Domain\Security\SecurityContextInterface;
@@ -58,6 +59,7 @@ use SharedKernel\Infrastructure\Logger\LoggerFactory;
 use SharedKernel\Infrastructure\Notification\Email\SenderRegistry;
 use Infrastructure\Notification\SmsNotifierFactory;
 use Infrastructure\Redis\RedisClientFactory;
+use Infrastructure\Redis\RedisMasterClientFactory;
 use SharedKernel\Infrastructure\Storage\CdnUrlResolver;
 use SharedKernel\Infrastructure\Storage\StorageFactory;
 use SharedKernel\Infrastructure\Throttle\ThrottleConfigDefaults;
@@ -76,6 +78,7 @@ $containerBuilder->addDefinitions(array_merge([
     Environment::class => DI\autowire(Environment::class)->constructor(Fuel::$env, getenv('TEST_ENV_ID') ?: null),
     LoggerInterface::class => DI\factory(LoggerFactory::class),
     RedisClientInterface::class => DI\factory(RedisClientFactory::class),
+    RedisMasterClientInterface::class => DI\factory(RedisMasterClientFactory::class),
     CacheInterface::class => DI\factory(CacheFactory::class),
     CdnUrlResolver::class => DI\autowire(CdnUrlResolver::class)->constructor([
         'public/images/' => getenv('CDN_IMAGES_URL') ?: '',

--- a/fuelphp/fuel/app/tests/infrastructure/redis/phpredisclient.php
+++ b/fuelphp/fuel/app/tests/infrastructure/redis/phpredisclient.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Fuel\Core;
+
+use Infrastructure\Redis\PhpRedisClient;
+use RuntimeException;
+
+/**
+ * @group App
+ * @group Redis
+ */
+class Test_PhpRedisClient extends TestCase
+{
+    public function test_from_config_section_throws_when_primary_host_is_empty()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('redis.primary.host is not configured (env REDIS_PRIMARY_ENDPOINT)');
+
+        PhpRedisClient::fromConfigSection([], 'primary');
+    }
+
+    public function test_from_config_section_throws_when_reader_host_is_empty()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('redis.reader.host is not configured (env REDIS_READER_ENDPOINT)');
+
+        PhpRedisClient::fromConfigSection(['host' => null], 'reader');
+    }
+}

--- a/fuelphp/fuel/packages/infrastructure/classes/Redis/PhpRedisClient.php
+++ b/fuelphp/fuel/packages/infrastructure/classes/Redis/PhpRedisClient.php
@@ -6,12 +6,49 @@ namespace Infrastructure\Redis;
 
 use Redis;
 use RedisException;
+use RuntimeException;
 use SharedKernel\Domain\Redis\Exceptions\RedisConnectionException;
-use SharedKernel\Domain\Redis\RedisClientInterface;
+use SharedKernel\Domain\Redis\RedisMasterClientInterface;
 
-class PhpRedisClient implements RedisClientInterface
+class PhpRedisClient implements RedisMasterClientInterface
 {
+    /**
+     * Maps config section to the env variable that ultimately backs its host.
+     * Used in the misconfiguration exception so on-call can grep the codebase
+     * for the env name they see in the alert.
+     */
+    private const HOST_ENV_BY_SECTION = [
+        'primary' => 'REDIS_PRIMARY_ENDPOINT',
+        'reader'  => 'REDIS_READER_ENDPOINT',
+    ];
+
     private Redis $client;
+
+    /**
+     * Build a client from a redis.php config section.
+     *
+     * @param array<string,mixed> $cfg
+     * @throws RuntimeException When the host is empty (misconfiguration).
+     */
+    public static function fromConfigSection(array $cfg, string $section): self
+    {
+        if (empty($cfg['host'])) {
+            $envName = self::HOST_ENV_BY_SECTION[$section] ?? '<unknown>';
+            throw new RuntimeException(sprintf(
+                'redis.%s.host is not configured (env %s)',
+                $section,
+                $envName
+            ));
+        }
+
+        return new self(new RedisConfig(
+            (string) $cfg['host'],
+            (int) ($cfg['port'] ?? 6379),
+            (int) ($cfg['database'] ?? 0),
+            (float) ($cfg['timeout'] ?? 5.0),
+            (string) ($cfg['connection_type'] ?? 'default')
+        ));
+    }
 
     public function __construct(RedisConfig $config)
     {
@@ -167,10 +204,5 @@ class PhpRedisClient implements RedisClientInterface
         } catch (RedisException $e) {
             throw RedisConnectionException::operationFailed('SETNX', $e->getMessage());
         }
-    }
-
-    public function getMaster(string $key): ?string
-    {
-        return $this->get($key);
     }
 }

--- a/fuelphp/fuel/packages/infrastructure/classes/Redis/RedisClientFactory.php
+++ b/fuelphp/fuel/packages/infrastructure/classes/Redis/RedisClientFactory.php
@@ -5,68 +5,25 @@ declare(strict_types=1);
 namespace Infrastructure\Redis;
 
 use Fuel\Core\Config;
-use RuntimeException;
 use SharedKernel\Domain\Redis\RedisClientInterface;
 use SharedKernel\Infrastructure\Redis\ReadWriteRedisClient;
 
 class RedisClientFactory
 {
-    /**
-     * Maps config section to the env variable that ultimately backs its host.
-     * Used in the misconfiguration exception so on-call can grep the codebase
-     * for the env name they see in the alert.
-     */
-    private const HOST_ENV_BY_SECTION = [
-        'primary' => 'REDIS_PRIMARY_ENDPOINT',
-        'reader'  => 'REDIS_READER_ENDPOINT',
-    ];
-
     public function __invoke(): RedisClientInterface
     {
         Config::load('redis', true);
 
-        $writeClient = $this->buildClient(Config::get('redis.primary', []), 'primary');
-        $readClient = $this->buildReader(Config::get('redis.reader', []), $writeClient);
+        $writeClient = PhpRedisClient::fromConfigSection(
+            Config::get('redis.primary', []),
+            'primary'
+        );
+
+        $readerCfg = Config::get('redis.reader', []);
+        $readClient = empty($readerCfg['host'])
+            ? $writeClient
+            : PhpRedisClient::fromConfigSection($readerCfg, 'reader');
 
         return new ReadWriteRedisClient($readClient, $writeClient);
-    }
-
-    /**
-     * Build a client from a config section, throwing if the host is missing.
-     *
-     * @param array<string,mixed> $cfg
-     */
-    private function buildClient(array $cfg, string $section): RedisClientInterface
-    {
-        if (empty($cfg['host'])) {
-            $envName = self::HOST_ENV_BY_SECTION[$section] ?? '<unknown>';
-            throw new RuntimeException(sprintf(
-                'redis.%s.host is not configured (env %s)',
-                $section,
-                $envName
-            ));
-        }
-
-        return new PhpRedisClient(new RedisConfig(
-            (string) $cfg['host'],
-            (int) ($cfg['port'] ?? 6379),
-            (int) ($cfg['database'] ?? 0),
-            (float) ($cfg['timeout'] ?? 5.0),
-            (string) ($cfg['connection_type'] ?? 'default')
-        ));
-    }
-
-    /**
-     * Reader falls back to the primary client when no reader host is configured.
-     *
-     * @param array<string,mixed> $cfg
-     */
-    private function buildReader(array $cfg, RedisClientInterface $writeClient): RedisClientInterface
-    {
-        if (empty($cfg['host'])) {
-            return $writeClient;
-        }
-
-        return $this->buildClient($cfg, 'reader');
     }
 }

--- a/fuelphp/fuel/packages/infrastructure/classes/Redis/RedisMasterClientFactory.php
+++ b/fuelphp/fuel/packages/infrastructure/classes/Redis/RedisMasterClientFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Infrastructure\Redis;
+
+use Fuel\Core\Config;
+use SharedKernel\Domain\Redis\RedisMasterClientInterface;
+
+/**
+ * Builds a master-only Redis client for strong-consistency consumers
+ * (e.g. RedisThrottler). Reads from redis.primary only — no reader
+ * fallback, no failover decorator. If the master is unreachable, the
+ * caller fails fast: for rate limiting that's the correct posture.
+ *
+ * Shares the same pconnect persistent-id ('master') as the write side
+ * of ReadWriteRedisClient, so both ultimately reuse the same TCP socket
+ * per FPM worker — no connection doubling.
+ */
+class RedisMasterClientFactory
+{
+    public function __invoke(): RedisMasterClientInterface
+    {
+        Config::load('redis', true);
+
+        return PhpRedisClient::fromConfigSection(
+            Config::get('redis.primary', []),
+            'primary'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Removes \`RedisClientInterface::getMaster()\` (topology leak in the domain contract) in favour of a marker \`RedisMasterClientInterface\`
- \`RedisThrottler\` now depends on the marker; cache stays on \`RedisClientInterface\` via \`ReadWriteRedisClient\`
- \`PhpRedisClient\` implements both interfaces; common config-section construction extracted to \`PhpRedisClient::fromConfigSection()\` so \`RedisClientFactory\` and the new \`RedisMasterClientFactory\` stay thin
- \`RedisMasterClientFactory\` reads \`redis.primary\` only — no reader fallback, no failover decorator. If the master is unreachable, rate limiting fails fast (correct posture for security-critical reads)
- ADR-001 extended with the strong-consistency section and a primary/reader (AWS) vs master/replica (Redis) terminology note

Closes #14.

## Test plan

- [x] \`make test-unit\` — 416 + 14 tests pass
- [x] phpstan level 5 — 0 errors
- [x] phpcs — clean
- [x] HTTP smoke: site \`/\` and \`admin.\` both 200
- [x] DI resolve via oil task: \`RedisClientInterface\` → \`ReadWriteRedisClient\`, \`RedisMasterClientInterface\` → \`PhpRedisClient\`, both ping OK