### PR TITLE
Add workflow + ADR + comment conventions to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,11 @@ Key constraints when working with the event system:
 - **New top-level namespace in `backend/composer.json`**: run `docker compose exec fuelphp composer -d /app/fuelphp update app/backend` after `make composer-autoload`. The path-repo lock on the fuelphp side doesn't pick up new top-level namespaces from a plain dump.
 - **Numeric clamps**: prefer `max(N, $x)` / `min(N, $x)` / `min(max($lo, $x), $hi)` over `$x < N ? N : $x` ternaries. The codebase already uses `max()` in `ProductSearchResult`, `FilterFacets`, `RedisThrottler`; align new code with that. Tertiary `?:` is fine for *fallback* semantics (e.g. `$perPage < 1 ? self::DEFAULT : $perPage` where zero means "unset", not "below the floor").
 
+## Git workflow
+
+- Stage with `git add -u` + explicit new-file paths. Avoid `git add -A` / `git add .` and don't list every tracked file by hand when `-u` covers them.
+- Commit messages: one-line conventional-style subject, body only if non-obvious *why* (not a recap of the diff). Two short lines beats six wordy ones.
+
 ## Development Commands
 
 ### Docker-based Development

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,8 @@ Key constraints when working with the event system:
 - **HTMX partial endpoints**: redirect non-HTMX callers to the user-facing URL; set `HX-Push-Url` so HTMX pushes the user-facing URL, not the partial endpoint. Reference: `Controller_Site_Home::action_products`.
 - **New top-level namespace in `backend/composer.json`**: run `docker compose exec fuelphp composer -d /app/fuelphp update app/backend` after `make composer-autoload`. The path-repo lock on the fuelphp side doesn't pick up new top-level namespaces from a plain dump.
 - **Numeric clamps**: prefer `max(N, $x)` / `min(N, $x)` / `min(max($lo, $x), $hi)` over `$x < N ? N : $x` ternaries. The codebase already uses `max()` in `ProductSearchResult`, `FilterFacets`, `RedisThrottler`; align new code with that. Tertiary `?:` is fine for *fallback* semantics (e.g. `$perPage < 1 ? self::DEFAULT : $perPage` where zero means "unset", not "below the floor").
+- **ADR style**: state the decision, then its rationale once. Don't repeat the same fact as prose + bullet list + ASCII diagram — pick one form. Cut anything that recaps the codebase rather than explaining a choice.
+- **Comments**: default to none. Write one only for non-obvious *why* (hidden constraint, workaround, surprising invariant). Don't restate the code, don't reference callers or PRs, don't write multi-line class headers that duplicate the ADR. Exception: phpstan-level-5 array `@param` shapes (`array<string,mixed>`) and `@throws` are kept — they're load-bearing, not prose. Legacy FuelPHP `@author`/version blocks are not the model.
 
 ## Git workflow
 


### PR DESCRIPTION
## Summary

Three small conventions distilled from recent reviews:

- **Git workflow**: stage with \`git add -u\` + explicit new files, not \`-A\`; keep commit messages one-line.
- **ADR style**: state each fact once; don't pair prose + bullet list + ASCII diagram saying the same thing.
- **Comments**: default to none; keep only non-obvious *why*. Phpstan array \`@param\` shapes and \`@throws\` are load-bearing exceptions.

## Test plan

- [x] Documentation-only — no code or tests touched.