### PR TITLE
fix: read DB credentials from RDS_* env vars with DB_* fallback

### DIFF
--- a/fuelphp/fuel/app/config/db.php
+++ b/fuelphp/fuel/app/config/db.php
@@ -24,11 +24,11 @@ return [
     'default' => [
         'type'        => 'mysqli',
         'connection'  => [
-            'hostname'   => getenv('DB_HOSTNAME'),
-            'port'       => getenv('DB_PORT') ?: 3306,
-            'database'   => getenv('DB_DB_NAME'),
-            'username'   => getenv('DB_USERNAME'),
-            'password'   => getenv('DB_PASSWORD'),
+            'hostname'   => getenv('RDS_HOSTNAME') ?: getenv('DB_HOSTNAME'),
+            'port'       => getenv('RDS_PORT') ?: (getenv('DB_PORT') ?: 3306),
+            'database'   => getenv('RDS_DB_NAME') ?: getenv('DB_DB_NAME'),
+            'username'   => getenv('RDS_USERNAME') ?: getenv('DB_USERNAME'),
+            'password'   => getenv('RDS_PASSWORD') ?: getenv('DB_PASSWORD'),
         ],
     ],
 


### PR DESCRIPTION
## Summary
- `db.php` was reading `DB_HOSTNAME` / `DB_DB_NAME` / `DB_USERNAME` / `DB_PASSWORD`, but `docker-compose.yml` only sets `RDS_*` (AWS Elastic Beanstalk convention). Connection was effectively empty in dev — went unnoticed because unit tests never exercise the DB
- Prefer `RDS_*` when set, fall back to `DB_*` so any environment still wired on the legacy names keeps working

## Test plan
- [x] Existing unit tests still green (`make test-unit`)
- [x] Lint still green (`make lint`)
- [x] `docker compose exec fuelphp php /app/fuelphp/oil refine migrate:current` now succeeds (was failing with `mysqli::__construct(): (HY000/2002): No such file or directory` because hostname was empty)