### PR TITLE
refactor: align repository field names with $<entity> convention

### DIFF
--- a/backend/src/Catalog/Application/Service/CatalogReadService.php
+++ b/backend/src/Catalog/Application/Service/CatalogReadService.php
@@ -26,11 +26,11 @@ final class CatalogReadService
     private const PER_PAGE_FALLBACK = 12;
     private const PAGE_HARD_CAP = 10000;
 
-    private ProductRepositoryInterface $repository;
+    private ProductRepositoryInterface $products;
 
-    public function __construct(ProductRepositoryInterface $repository)
+    public function __construct(ProductRepositoryInterface $products)
     {
-        $this->repository = $repository;
+        $this->products = $products;
     }
 
     public function searchProducts(SearchFilters $filters, int $page, int $perPage): ProductSearchResult
@@ -41,9 +41,9 @@ final class CatalogReadService
         $page = min(max(1, $page), self::PAGE_HARD_CAP);
         $perPage = $perPage < 1 ? self::PER_PAGE_FALLBACK : $perPage;
 
-        $result = $this->repository->findByFilters($filters, $page, $perPage);
+        $result = $this->products->findByFilters($filters, $page, $perPage);
 
-        $facets = $this->repository->getFacets();
+        $facets = $this->products->getFacets();
         $brandsById = $this->indexBrandsById($facets['brands']);
         $categoriesById = $this->indexCategoriesById($facets['categories']);
 
@@ -57,7 +57,7 @@ final class CatalogReadService
 
     public function getFilterFacets(): FilterFacets
     {
-        $facets = $this->repository->getFacets();
+        $facets = $this->products->getFacets();
 
         return new FilterFacets(
             $facets['categories'],

--- a/backend/src/SharedKernel/Infrastructure/EventSystem/AsyncEventProcessor.php
+++ b/backend/src/SharedKernel/Infrastructure/EventSystem/AsyncEventProcessor.php
@@ -17,20 +17,20 @@ use SharedKernel\Domain\Logger\LoggerInterface;
  */
 final class AsyncEventProcessor extends AbstractEventProcessor implements AsyncEventProcessorInterface
 {
-    private AsyncRepositoryInterface $asyncEventRepository;
+    private AsyncRepositoryInterface $events;
 
     public function __construct(
-        AsyncRepositoryInterface $asyncEventRepository,
+        AsyncRepositoryInterface $events,
         ListenerProviderInterface $listenerProvider,
         LoggerInterface $logger
     ) {
         parent::__construct($listenerProvider, $logger);
-        $this->asyncEventRepository = $asyncEventRepository;
+        $this->events = $events;
     }
 
     protected function getRepository(): EventRepositoryInterface
     {
-        return $this->asyncEventRepository;
+        return $this->events;
     }
 
     protected function getEventTypeLabel(): string

--- a/backend/src/SharedKernel/Infrastructure/EventSystem/OutboxEventProcessor.php
+++ b/backend/src/SharedKernel/Infrastructure/EventSystem/OutboxEventProcessor.php
@@ -11,20 +11,20 @@ use SharedKernel\Domain\Logger\LoggerInterface;
 
 final class OutboxEventProcessor extends AbstractEventProcessor implements OutboxEventProcessorInterface
 {
-    private EventRepositoryInterface $repository;
+    private EventRepositoryInterface $events;
 
     public function __construct(
-        EventRepositoryInterface $repository,
+        EventRepositoryInterface $events,
         ListenerProviderInterface $listenerProvider,
         LoggerInterface $logger
     ) {
         parent::__construct($listenerProvider, $logger);
-        $this->repository = $repository;
+        $this->events = $events;
     }
 
     protected function getRepository(): EventRepositoryInterface
     {
-        return $this->repository;
+        return $this->events;
     }
 
     protected function getEventTypeLabel(): string

--- a/backend/src/SharedKernel/Infrastructure/EventSystem/ScheduledEventProcessor.php
+++ b/backend/src/SharedKernel/Infrastructure/EventSystem/ScheduledEventProcessor.php
@@ -19,20 +19,20 @@ use SharedKernel\Domain\Logger\LoggerInterface;
  */
 final class ScheduledEventProcessor extends AbstractEventProcessor implements ScheduledEventProcessorInterface
 {
-    private EventRepositoryInterface $scheduledEventRepository;
+    private EventRepositoryInterface $events;
 
     public function __construct(
-        EventRepositoryInterface $scheduledEventRepository,
+        EventRepositoryInterface $events,
         ListenerProviderInterface $listenerProvider,
         LoggerInterface $logger
     ) {
         parent::__construct($listenerProvider, $logger);
-        $this->scheduledEventRepository = $scheduledEventRepository;
+        $this->events = $events;
     }
 
     protected function getRepository(): EventRepositoryInterface
     {
-        return $this->scheduledEventRepository;
+        return $this->events;
     }
 
     protected function getEventTypeLabel(): string


### PR DESCRIPTION
## Summary
- Security code already follows the DDD convention of naming repository fields after **what** is stored, not the technical role (`$users`, `$tokens`)
- Catalog and EventSystem still used `$repository` / `$asyncEventRepository` / `$scheduledEventRepository`
- Rename for consistency: `CatalogReadService` → `$products`; the three event processors share `$events`. The type already says "repository"

## Test plan
- [x] `make test-unit` — 443 backend + 40 fuelphp pass
- [x] `make lint` — clean
- [x] PHPStan — clean