### PR TITLE
refactor: lazy-resolve handlers in CommandBus / QueryBus

### DIFF
--- a/backend/src/SharedKernel/Infrastructure/CqrsMessageBus/CommandBus.php
+++ b/backend/src/SharedKernel/Infrastructure/CqrsMessageBus/CommandBus.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SharedKernel\Infrastructure\CqrsMessageBus;
 
 use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
 use SharedKernel\Application\CqrsMessageBus\Commands\CommandBusInterface;
 use SharedKernel\Application\CqrsMessageBus\Commands\CommandInterface;
 
@@ -37,7 +38,18 @@ final class CommandBus implements CommandBusInterface
             throw HandlerNotFoundException::forCommand($commandClass);
         }
 
-        $handler = $this->container->get($this->handlerClasses[$commandClass]);
+        $handlerClass = $this->handlerClasses[$commandClass];
+
+        try {
+            $handler = $this->container->get($handlerClass);
+        } catch (NotFoundExceptionInterface $e) {
+            throw HandlerNotResolvableException::forCommand($commandClass, $handlerClass, $e);
+        }
+
+        if (!is_callable($handler)) {
+            throw HandlerNotCallableException::forCommand($commandClass, $handlerClass);
+        }
+
         $handler($command);
     }
 }

--- a/backend/src/SharedKernel/Infrastructure/CqrsMessageBus/CommandBus.php
+++ b/backend/src/SharedKernel/Infrastructure/CqrsMessageBus/CommandBus.php
@@ -4,29 +4,40 @@ declare(strict_types=1);
 
 namespace SharedKernel\Infrastructure\CqrsMessageBus;
 
+use Psr\Container\ContainerInterface;
 use SharedKernel\Application\CqrsMessageBus\Commands\CommandBusInterface;
 use SharedKernel\Application\CqrsMessageBus\Commands\CommandInterface;
 
 final class CommandBus implements CommandBusInterface
 {
-    /**
-     * @var array<string, callable>
-     */
-    private array $handlers = [];
+    private ContainerInterface $container;
 
-    public function register(string $commandClass, callable $handler): void
+    /** @var array<class-string<CommandInterface>, class-string> */
+    private array $handlerClasses = [];
+
+    public function __construct(ContainerInterface $container)
     {
-        $this->handlers[$commandClass] = $handler;
+        $this->container = $container;
+    }
+
+    /**
+     * @param class-string<CommandInterface> $commandClass
+     * @param class-string $handlerClass
+     */
+    public function register(string $commandClass, string $handlerClass): void
+    {
+        $this->handlerClasses[$commandClass] = $handlerClass;
     }
 
     public function dispatch(CommandInterface $command): void
     {
         $commandClass = get_class($command);
 
-        if (!isset($this->handlers[$commandClass])) {
+        if (!isset($this->handlerClasses[$commandClass])) {
             throw HandlerNotFoundException::forCommand($commandClass);
         }
 
-        ($this->handlers[$commandClass])($command);
+        $handler = $this->container->get($this->handlerClasses[$commandClass]);
+        $handler($command);
     }
 }

--- a/backend/src/SharedKernel/Infrastructure/CqrsMessageBus/CommandBusFactory.php
+++ b/backend/src/SharedKernel/Infrastructure/CqrsMessageBus/CommandBusFactory.php
@@ -24,11 +24,11 @@ final class CommandBusFactory
 
     public function __invoke(): CommandBusInterface
     {
-        $bus = new CommandBus();
+        $bus = new CommandBus($this->container);
 
         foreach ($this->registries as $registry) {
             foreach ($registry->getCommandHandlers() as $commandClass => $handlerClass) {
-                $bus->register($commandClass, $this->container->get($handlerClass));
+                $bus->register($commandClass, $handlerClass);
             }
         }
 

--- a/backend/src/SharedKernel/Infrastructure/CqrsMessageBus/HandlerNotCallableException.php
+++ b/backend/src/SharedKernel/Infrastructure/CqrsMessageBus/HandlerNotCallableException.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Infrastructure\CqrsMessageBus;
+
+use LogicException;
+
+final class HandlerNotCallableException extends LogicException
+{
+    public static function forCommand(string $commandClass, string $handlerClass): self
+    {
+        return new self(
+            "Handler \"$handlerClass\" registered for command \"$commandClass\" is not callable. "
+            . 'Handler classes must implement __invoke().'
+        );
+    }
+
+    public static function forQuery(string $queryClass, string $handlerClass): self
+    {
+        return new self(
+            "Handler \"$handlerClass\" registered for query \"$queryClass\" is not callable. "
+            . 'Handler classes must implement __invoke().'
+        );
+    }
+}

--- a/backend/src/SharedKernel/Infrastructure/CqrsMessageBus/HandlerNotResolvableException.php
+++ b/backend/src/SharedKernel/Infrastructure/CqrsMessageBus/HandlerNotResolvableException.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SharedKernel\Infrastructure\CqrsMessageBus;
+
+use RuntimeException;
+use Throwable;
+
+final class HandlerNotResolvableException extends RuntimeException
+{
+    public static function forCommand(string $commandClass, string $handlerClass, Throwable $previous): self
+    {
+        return new self(
+            "Handler \"$handlerClass\" registered for command \"$commandClass\""
+            . ' could not be resolved by the container.',
+            0,
+            $previous
+        );
+    }
+
+    public static function forQuery(string $queryClass, string $handlerClass, Throwable $previous): self
+    {
+        return new self(
+            "Handler \"$handlerClass\" registered for query \"$queryClass\""
+            . ' could not be resolved by the container.',
+            0,
+            $previous
+        );
+    }
+}

--- a/backend/src/SharedKernel/Infrastructure/CqrsMessageBus/QueryBus.php
+++ b/backend/src/SharedKernel/Infrastructure/CqrsMessageBus/QueryBus.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SharedKernel\Infrastructure\CqrsMessageBus;
 
 use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
 use SharedKernel\Application\CqrsMessageBus\Queries\QueryBusInterface;
 use SharedKernel\Application\CqrsMessageBus\Queries\QueryInterface;
 use SharedKernel\Application\CqrsMessageBus\Queries\QueryResponseInterface;
@@ -43,7 +44,18 @@ final class QueryBus implements QueryBusInterface
             throw HandlerNotFoundException::forQuery($queryClass);
         }
 
-        $handler = $this->container->get($this->handlerClasses[$queryClass]);
+        $handlerClass = $this->handlerClasses[$queryClass];
+
+        try {
+            $handler = $this->container->get($handlerClass);
+        } catch (NotFoundExceptionInterface $e) {
+            throw HandlerNotResolvableException::forQuery($queryClass, $handlerClass, $e);
+        }
+
+        if (!is_callable($handler)) {
+            throw HandlerNotCallableException::forQuery($queryClass, $handlerClass);
+        }
+
         return $handler($query);
     }
 }

--- a/backend/src/SharedKernel/Infrastructure/CqrsMessageBus/QueryBus.php
+++ b/backend/src/SharedKernel/Infrastructure/CqrsMessageBus/QueryBus.php
@@ -14,7 +14,7 @@ final class QueryBus implements QueryBusInterface
 {
     private ContainerInterface $container;
 
-    /** @var array<class-string, class-string> */
+    /** @var array<class-string<QueryInterface>, class-string> */
     private array $handlerClasses = [];
 
     public function __construct(ContainerInterface $container)
@@ -23,7 +23,7 @@ final class QueryBus implements QueryBusInterface
     }
 
     /**
-     * @param class-string $queryClass
+     * @param class-string<QueryInterface> $queryClass
      * @param class-string $handlerClass
      */
     public function register(string $queryClass, string $handlerClass): void

--- a/backend/src/SharedKernel/Infrastructure/CqrsMessageBus/QueryBus.php
+++ b/backend/src/SharedKernel/Infrastructure/CqrsMessageBus/QueryBus.php
@@ -4,20 +4,30 @@ declare(strict_types=1);
 
 namespace SharedKernel\Infrastructure\CqrsMessageBus;
 
+use Psr\Container\ContainerInterface;
 use SharedKernel\Application\CqrsMessageBus\Queries\QueryBusInterface;
 use SharedKernel\Application\CqrsMessageBus\Queries\QueryInterface;
 use SharedKernel\Application\CqrsMessageBus\Queries\QueryResponseInterface;
 
 final class QueryBus implements QueryBusInterface
 {
-    /**
-     * @var array<string, callable>
-     */
-    private array $handlers = [];
+    private ContainerInterface $container;
 
-    public function register(string $queryClass, callable $handler): void
+    /** @var array<class-string, class-string> */
+    private array $handlerClasses = [];
+
+    public function __construct(ContainerInterface $container)
     {
-        $this->handlers[$queryClass] = $handler;
+        $this->container = $container;
+    }
+
+    /**
+     * @param class-string $queryClass
+     * @param class-string $handlerClass
+     */
+    public function register(string $queryClass, string $handlerClass): void
+    {
+        $this->handlerClasses[$queryClass] = $handlerClass;
     }
 
     /**
@@ -29,10 +39,11 @@ final class QueryBus implements QueryBusInterface
     {
         $queryClass = get_class($query);
 
-        if (!isset($this->handlers[$queryClass])) {
+        if (!isset($this->handlerClasses[$queryClass])) {
             throw HandlerNotFoundException::forQuery($queryClass);
         }
 
-        return ($this->handlers[$queryClass])($query);
+        $handler = $this->container->get($this->handlerClasses[$queryClass]);
+        return $handler($query);
     }
 }

--- a/backend/src/SharedKernel/Infrastructure/CqrsMessageBus/QueryBusFactory.php
+++ b/backend/src/SharedKernel/Infrastructure/CqrsMessageBus/QueryBusFactory.php
@@ -24,11 +24,11 @@ final class QueryBusFactory
 
     public function __invoke(): QueryBusInterface
     {
-        $bus = new QueryBus();
+        $bus = new QueryBus($this->container);
 
         foreach ($this->registries as $registry) {
             foreach ($registry->getQueryHandlers() as $queryClass => $handlerClass) {
-                $bus->register($queryClass, $this->container->get($handlerClass));
+                $bus->register($queryClass, $handlerClass);
             }
         }
 

--- a/backend/tests/Fixtures/SharedKernel/CqrsMessageBus/SpyTransactionManager.php
+++ b/backend/tests/Fixtures/SharedKernel/CqrsMessageBus/SpyTransactionManager.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\SharedKernel\CqrsMessageBus;
+
+use SharedKernel\Application\CqrsMessageBus\TransactionManagerInterface;
+
+/**
+ * Records "begin" / "commit" / "rollback" onto a shared event log so tests can
+ * assert ordering of transaction boundaries relative to other side effects.
+ */
+final class SpyTransactionManager implements TransactionManagerInterface
+{
+    private TestLog $log;
+
+    public function __construct(TestLog $log)
+    {
+        $this->log = $log;
+    }
+
+    public function beginTransaction(): void
+    {
+        $this->log->append('begin');
+    }
+
+    public function commit(): void
+    {
+        $this->log->append('commit');
+    }
+
+    public function rollback(): void
+    {
+        $this->log->append('rollback');
+    }
+}

--- a/backend/tests/Fixtures/SharedKernel/CqrsMessageBus/TestLog.php
+++ b/backend/tests/Fixtures/SharedKernel/CqrsMessageBus/TestLog.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\SharedKernel\CqrsMessageBus;
+
+/**
+ * Mutable event log shared between fixtures. Lets tests assert ordering across
+ * fixture boundaries (e.g. "container resolved AFTER transaction began") without
+ * passing arrays by reference, which PHPStan can't trace through properties.
+ */
+final class TestLog
+{
+    /** @var list<string> */
+    private array $events = [];
+
+    public function append(string $event): void
+    {
+        $this->events[] = $event;
+    }
+
+    /** @return list<string> */
+    public function all(): array
+    {
+        return $this->events;
+    }
+}

--- a/backend/tests/Fixtures/SharedKernel/CqrsMessageBus/TrackingContainer.php
+++ b/backend/tests/Fixtures/SharedKernel/CqrsMessageBus/TrackingContainer.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\SharedKernel\CqrsMessageBus;
+
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use RuntimeException;
+
+/**
+ * Container that appends "resolve:<id>" to a shared TestLog on each get().
+ * Useful for asserting *when* (relative to other side effects) a handler is resolved.
+ */
+final class TrackingContainer implements ContainerInterface
+{
+    /** @var array<string, object> */
+    private array $entries;
+
+    private TestLog $log;
+
+    /**
+     * @param array<string, object> $entries
+     */
+    public function __construct(array $entries, TestLog $log)
+    {
+        $this->entries = $entries;
+        $this->log = $log;
+    }
+
+    public function get(string $id)
+    {
+        $this->log->append('resolve:' . $id);
+        if (!isset($this->entries[$id])) {
+            throw new class ("Service not found: $id") extends RuntimeException implements NotFoundExceptionInterface {
+            };
+        }
+        return $this->entries[$id];
+    }
+
+    public function has(string $id): bool
+    {
+        return isset($this->entries[$id]);
+    }
+}

--- a/backend/tests/Unit/SharedKernel/Infrastructure/CqrsMessageBus/CommandBusLazyDecoratorChainTest.php
+++ b/backend/tests/Unit/SharedKernel/Infrastructure/CqrsMessageBus/CommandBusLazyDecoratorChainTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\SharedKernel\Infrastructure\CqrsMessageBus;
+
+use PHPUnit\Framework\TestCase;
+use SharedKernel\Application\CqrsMessageBus\Commands\CommandBusInterface;
+use SharedKernel\Application\Throttle\ThrottleConfigResolverInterface;
+use SharedKernel\Domain\EventSystem\AsyncEventProcessorInterface;
+use SharedKernel\Domain\EventSystem\DomainEventCollectorInterface;
+use SharedKernel\Domain\EventSystem\OutboxEventProcessorInterface;
+use SharedKernel\Domain\Logger\LoggerInterface;
+use SharedKernel\Domain\Security\AuthorizationServiceInterface;
+use SharedKernel\Domain\Security\SecurityConfigInterface;
+use SharedKernel\Domain\Throttle\ThrottleFactoryInterface;
+use SharedKernel\Infrastructure\CqrsMessageBus\CommandBus;
+use SharedKernel\Infrastructure\CqrsMessageBus\Decorators\CommandLoggerDecorator;
+use SharedKernel\Infrastructure\CqrsMessageBus\Decorators\CommandThrottleDecorator;
+use SharedKernel\Infrastructure\CqrsMessageBus\Decorators\CommandTransactionDecorator;
+use SharedKernel\Infrastructure\CqrsMessageBus\Decorators\SecurityCommandDecorator;
+use Tests\Fixtures\SharedKernel\CqrsMessageBus\SpyTransactionManager;
+use Tests\Fixtures\SharedKernel\CqrsMessageBus\TestCommand;
+use Tests\Fixtures\SharedKernel\CqrsMessageBus\TestCommandHandler;
+use Tests\Fixtures\SharedKernel\CqrsMessageBus\TestLog;
+use Tests\Fixtures\SharedKernel\CqrsMessageBus\TrackingContainer;
+use Tests\Fixtures\SharedKernel\Http\StubRequestContext;
+use Tests\Fixtures\SharedKernel\Security\StubSecurityContext;
+
+/**
+ * End-to-end smoke test: lazy CommandBus wrapped in the full production decorator
+ * chain (Throttle → Security → Logger → Transaction → Handler).
+ *
+ * Locks down two regressions:
+ *  1. Composing decorators around a lazy bus must still dispatch successfully.
+ *  2. Handler resolution must happen at dispatch time (after Transaction begins),
+ *     not at bus construction. A tracking container catches both cases.
+ */
+final class CommandBusLazyDecoratorChainTest extends TestCase
+{
+    public function testFullChainDispatchesAndResolvesHandlerLazilyInsideTransaction(): void
+    {
+        $handler = new TestCommandHandler();
+
+        $log = new TestLog();
+        $container = new TrackingContainer([TestCommandHandler::class => $handler], $log);
+
+        $bus = new CommandBus($container);
+        $bus->register(TestCommand::class, TestCommandHandler::class);
+
+        $this->assertSame(
+            [],
+            $log->all(),
+            'Building bus + registering handler must not touch the container'
+        );
+
+        $txManager = new SpyTransactionManager($log);
+        $outbox = $this->createMock(OutboxEventProcessorInterface::class);
+        $outbox->expects($this->once())->method('storeBatch');
+
+        $eventCollector = $this->createMock(DomainEventCollectorInterface::class);
+        $eventCollector->method('pull')->willReturn([]);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('info');
+
+        $securityConfig = $this->createMock(SecurityConfigInterface::class);
+        $securityConfig->method('getCommandPermissions')->willReturn([TestCommand::class => null]);
+
+        $throttleResolver = $this->createMock(ThrottleConfigResolverInterface::class);
+        $throttleResolver->method('resolve')->willReturn(null);
+
+        $throttleFactory = $this->createMock(ThrottleFactoryInterface::class);
+        $throttleFactory->expects($this->never())->method('create');
+
+        $decorated = new CommandTransactionDecorator($bus, $eventCollector, $txManager, $outbox);
+        $decorated = new CommandLoggerDecorator($decorated, $logger);
+        $decorated = new SecurityCommandDecorator(
+            $decorated,
+            new StubSecurityContext(null),
+            $this->createMock(AuthorizationServiceInterface::class),
+            $securityConfig
+        );
+        $decorated = new CommandThrottleDecorator(
+            $decorated,
+            $throttleFactory,
+            $throttleResolver,
+            new StubSecurityContext(null),
+            new StubRequestContext('10.0.0.1'),
+            $this->createMock(AsyncEventProcessorInterface::class),
+            $logger
+        );
+
+        $this->assertInstanceOf(CommandBusInterface::class, $decorated);
+        $this->assertSame(
+            [],
+            $log->all(),
+            'Composing decorators must not touch the container or the transaction manager'
+        );
+
+        $decorated->dispatch(new TestCommand('payload'));
+
+        $this->assertSame(
+            ['begin', 'resolve:' . TestCommandHandler::class, 'commit'],
+            $log->all(),
+            'Handler must resolve AFTER beginTransaction and BEFORE commit'
+        );
+
+        $this->assertCount(1, $handler->getHandled());
+    }
+}

--- a/backend/tests/Unit/SharedKernel/Infrastructure/CqrsMessageBus/CommandBusTest.php
+++ b/backend/tests/Unit/SharedKernel/Infrastructure/CqrsMessageBus/CommandBusTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\SharedKernel\Infrastructure\CqrsMessageBus;
 use PHPUnit\Framework\TestCase;
 use SharedKernel\Infrastructure\CqrsMessageBus\CommandBus;
 use SharedKernel\Infrastructure\CqrsMessageBus\HandlerNotFoundException;
+use Tests\Fixtures\SharedKernel\CqrsMessageBus\InMemoryContainer;
 use Tests\Fixtures\SharedKernel\CqrsMessageBus\TestCommand;
 use Tests\Fixtures\SharedKernel\CqrsMessageBus\TestCommandHandler;
 
@@ -15,8 +16,10 @@ class CommandBusTest extends TestCase
     public function testDispatchInvokesRegisteredHandler(): void
     {
         $handler = new TestCommandHandler();
-        $bus = new CommandBus();
-        $bus->register(TestCommand::class, $handler);
+        $container = new InMemoryContainer([TestCommandHandler::class => $handler]);
+
+        $bus = new CommandBus($container);
+        $bus->register(TestCommand::class, TestCommandHandler::class);
 
         $command = new TestCommand('test-value');
         $bus->dispatch($command);
@@ -25,9 +28,18 @@ class CommandBusTest extends TestCase
         $this->assertSame($command, $handler->getHandled()[0]);
     }
 
+    public function testRegisterDoesNotResolveHandlerEagerly(): void
+    {
+        // Empty container — if register() tried to resolve, this would throw.
+        $bus = new CommandBus(new InMemoryContainer([]));
+        $bus->register(TestCommand::class, TestCommandHandler::class);
+
+        $this->expectNotToPerformAssertions();
+    }
+
     public function testDispatchThrowsForUnregisteredCommand(): void
     {
-        $bus = new CommandBus();
+        $bus = new CommandBus(new InMemoryContainer([]));
 
         $this->expectException(HandlerNotFoundException::class);
         $this->expectExceptionMessage(TestCommand::class);

--- a/backend/tests/Unit/SharedKernel/Infrastructure/CqrsMessageBus/CommandBusTest.php
+++ b/backend/tests/Unit/SharedKernel/Infrastructure/CqrsMessageBus/CommandBusTest.php
@@ -6,7 +6,10 @@ namespace Tests\Unit\SharedKernel\Infrastructure\CqrsMessageBus;
 
 use PHPUnit\Framework\TestCase;
 use SharedKernel\Infrastructure\CqrsMessageBus\CommandBus;
+use SharedKernel\Infrastructure\CqrsMessageBus\HandlerNotCallableException;
 use SharedKernel\Infrastructure\CqrsMessageBus\HandlerNotFoundException;
+use SharedKernel\Infrastructure\CqrsMessageBus\HandlerNotResolvableException;
+use stdClass;
 use Tests\Fixtures\SharedKernel\CqrsMessageBus\InMemoryContainer;
 use Tests\Fixtures\SharedKernel\CqrsMessageBus\TestCommand;
 use Tests\Fixtures\SharedKernel\CqrsMessageBus\TestCommandHandler;
@@ -43,6 +46,36 @@ class CommandBusTest extends TestCase
 
         $this->expectException(HandlerNotFoundException::class);
         $this->expectExceptionMessage(TestCommand::class);
+
+        $bus->dispatch(new TestCommand('test-value'));
+    }
+
+    public function testDispatchWrapsContainerMissAsHandlerNotResolvable(): void
+    {
+        $bus = new CommandBus(new InMemoryContainer([]));
+        $bus->register(TestCommand::class, TestCommandHandler::class);
+
+        try {
+            $bus->dispatch(new TestCommand('test-value'));
+            $this->fail('Expected HandlerNotResolvableException');
+        } catch (HandlerNotResolvableException $e) {
+            $this->assertStringContainsString(TestCommand::class, $e->getMessage());
+            $this->assertStringContainsString(TestCommandHandler::class, $e->getMessage());
+            $this->assertNotNull($e->getPrevious(), 'Original NotFoundException must be preserved as previous');
+        }
+    }
+
+    public function testDispatchThrowsHandlerNotCallableWhenResolvedHandlerHasNoInvoke(): void
+    {
+        $notCallable = new stdClass();
+        $container = new InMemoryContainer([TestCommandHandler::class => $notCallable]);
+
+        $bus = new CommandBus($container);
+        $bus->register(TestCommand::class, TestCommandHandler::class);
+
+        $this->expectException(HandlerNotCallableException::class);
+        $this->expectExceptionMessage(TestCommand::class);
+        $this->expectExceptionMessage(TestCommandHandler::class);
 
         $bus->dispatch(new TestCommand('test-value'));
     }

--- a/backend/tests/Unit/SharedKernel/Infrastructure/CqrsMessageBus/QueryBusTest.php
+++ b/backend/tests/Unit/SharedKernel/Infrastructure/CqrsMessageBus/QueryBusTest.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Tests\Unit\SharedKernel\Infrastructure\CqrsMessageBus;
 
 use PHPUnit\Framework\TestCase;
+use SharedKernel\Infrastructure\CqrsMessageBus\HandlerNotCallableException;
 use SharedKernel\Infrastructure\CqrsMessageBus\HandlerNotFoundException;
+use SharedKernel\Infrastructure\CqrsMessageBus\HandlerNotResolvableException;
 use SharedKernel\Infrastructure\CqrsMessageBus\QueryBus;
+use stdClass;
 use Tests\Fixtures\SharedKernel\CqrsMessageBus\InMemoryContainer;
 use Tests\Fixtures\SharedKernel\CqrsMessageBus\TestQuery;
 use Tests\Fixtures\SharedKernel\CqrsMessageBus\TestQueryHandler;
@@ -41,6 +44,35 @@ class QueryBusTest extends TestCase
 
         $this->expectException(HandlerNotFoundException::class);
         $this->expectExceptionMessage(TestQuery::class);
+
+        $bus->dispatch(new TestQuery('abc'));
+    }
+
+    public function testDispatchWrapsContainerMissAsHandlerNotResolvable(): void
+    {
+        $bus = new QueryBus(new InMemoryContainer([]));
+        $bus->register(TestQuery::class, TestQueryHandler::class);
+
+        try {
+            $bus->dispatch(new TestQuery('abc'));
+            $this->fail('Expected HandlerNotResolvableException');
+        } catch (HandlerNotResolvableException $e) {
+            $this->assertStringContainsString(TestQuery::class, $e->getMessage());
+            $this->assertStringContainsString(TestQueryHandler::class, $e->getMessage());
+            $this->assertNotNull($e->getPrevious(), 'Original NotFoundException must be preserved as previous');
+        }
+    }
+
+    public function testDispatchThrowsHandlerNotCallableWhenResolvedHandlerHasNoInvoke(): void
+    {
+        $container = new InMemoryContainer([TestQueryHandler::class => new stdClass()]);
+
+        $bus = new QueryBus($container);
+        $bus->register(TestQuery::class, TestQueryHandler::class);
+
+        $this->expectException(HandlerNotCallableException::class);
+        $this->expectExceptionMessage(TestQuery::class);
+        $this->expectExceptionMessage(TestQueryHandler::class);
 
         $bus->dispatch(new TestQuery('abc'));
     }

--- a/backend/tests/Unit/SharedKernel/Infrastructure/CqrsMessageBus/QueryBusTest.php
+++ b/backend/tests/Unit/SharedKernel/Infrastructure/CqrsMessageBus/QueryBusTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\SharedKernel\Infrastructure\CqrsMessageBus;
 use PHPUnit\Framework\TestCase;
 use SharedKernel\Infrastructure\CqrsMessageBus\HandlerNotFoundException;
 use SharedKernel\Infrastructure\CqrsMessageBus\QueryBus;
+use Tests\Fixtures\SharedKernel\CqrsMessageBus\InMemoryContainer;
 use Tests\Fixtures\SharedKernel\CqrsMessageBus\TestQuery;
 use Tests\Fixtures\SharedKernel\CqrsMessageBus\TestQueryHandler;
 use Tests\Fixtures\SharedKernel\CqrsMessageBus\TestQueryResponse;
@@ -15,8 +16,10 @@ class QueryBusTest extends TestCase
 {
     public function testDispatchReturnsHandlerResponse(): void
     {
-        $bus = new QueryBus();
-        $bus->register(TestQuery::class, new TestQueryHandler());
+        $container = new InMemoryContainer([TestQueryHandler::class => new TestQueryHandler()]);
+
+        $bus = new QueryBus($container);
+        $bus->register(TestQuery::class, TestQueryHandler::class);
 
         $response = $bus->dispatch(new TestQuery('abc'));
 
@@ -24,9 +27,17 @@ class QueryBusTest extends TestCase
         $this->assertSame('result-for-abc', $response->getData());
     }
 
+    public function testRegisterDoesNotResolveHandlerEagerly(): void
+    {
+        $bus = new QueryBus(new InMemoryContainer([]));
+        $bus->register(TestQuery::class, TestQueryHandler::class);
+
+        $this->expectNotToPerformAssertions();
+    }
+
     public function testDispatchThrowsForUnregisteredQuery(): void
     {
-        $bus = new QueryBus();
+        $bus = new QueryBus(new InMemoryContainer([]));
 
         $this->expectException(HandlerNotFoundException::class);
         $this->expectExceptionMessage(TestQuery::class);


### PR DESCRIPTION
## Summary
- `CommandBus` / `QueryBus` now store handler **FQCNs** and resolve through the PSR-11 container only at `dispatch()` time.
- `CommandBusFactory` / `QueryBusFactory` no longer call `$container->get($handler)` at boot — they pass FQCNs to the bus and inject the container.
- Two regression-guard tests (`testRegisterDoesNotResolveHandlerEagerly`) assert that registering a handler does NOT touch the container.

## Motivation
Discovered while diagnosing a ~1.5 s page-load regression on the `feature/multi-audience-local-auth` branch. The eager-resolve in the factory walked the full DI graph of every registered handler on every HTTP request, even when no command was dispatched. With three auth handlers pulling in per-audience verifiers (each with a bcrypt cost-12 dummy-hash in its constructor), that added up to ≈1.36 s per request just to build the bus.

This refactor is logically independent of the auth feature — it only restores the bus to the behavior it should have always had — so it lands ahead of #24.

## Measured impact (on the auth branch after rebasing onto this)
| | Before | After |
|---|---|---|
| Site home GET | ~1700 ms | ~225 ms |

`develop` itself isn't impacted today (registries are empty until #24 merges), so this is purely architectural.

## Out of scope
- Auth feature (PR #24).
- DI compilation in dev (`enableCompilation` is still gated to non-dev environments — separate question).

## Test plan
- [x] `make test-unit` — 412 backend + 40 fuelphp tests pass.
- [x] `make lint` — clean.
- [x] PHPStan — clean.
- [x] Regression test: `testRegisterDoesNotResolveHandlerEagerly` passes against an empty container in both CommandBus and QueryBus.