### PR TITLE
chore: pin Node base image to 24-alpine

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -244,7 +244,7 @@ services:
       - sms
 
   frontend:
-    image: node:20-alpine
+    image: node:24-alpine
     working_dir: /app/frontend
     command: sh -c "npm install --no-audit --no-fund && npm run watch"
     volumes:

--- a/docker/fuelphp/nginx.dockerfile
+++ b/docker/fuelphp/nginx.dockerfile
@@ -1,5 +1,5 @@
 ARG NGINX_IMAGE=nginx:alpine
-ARG ASSETS_IMAGE=node:latest
+ARG ASSETS_IMAGE=node:24-alpine
 
 FROM $ASSETS_IMAGE AS assets
 WORKDIR /app

--- a/docker/fuelphp/php.dockerfile
+++ b/docker/fuelphp/php.dockerfile
@@ -1,6 +1,6 @@
 ARG PHP_IMAGE=php:latest
 ARG COMPOSER_IMAGE=composer:latest
-ARG ASSETS_IMAGE=node:latest
+ARG ASSETS_IMAGE=node:24-alpine
 
 FROM $ASSETS_IMAGE AS assets
 WORKDIR /app


### PR DESCRIPTION
## Summary

- Pin all three Node references to `node:24-alpine` (Active LTS until October 2026): the dev `frontend` compose service and both prod build-stage Dockerfiles for FuelPHP.
- Replaces unmaintained `node:20-alpine` (Iron, EOL April 2026) and floating `node:latest` (currently resolves to v26.x — not even LTS).

Prereq for #28 (Vite upgrade), which requires Node ≥20.19/22.12.

Closes #27.

## Test plan

- [x] `docker compose rm -fsv frontend && docker volume rm php-ddd_php-ddd-frontend-node-modules && docker compose up -d frontend`
- [x] `node --version` inside container → `v24.16.0`
- [x] `npm install` clean (12 packages, no warnings)
- [x] `vite build --watch` produces `dist/.vite/manifest.json`
- [x] `curl -sk https://php-ddd.test/` → 200, HTML references new asset hashes from rebuilt manifest
- [x] Hashed JS/CSS served 200 via nginx `/build/*`
- [x] Manifest JSON is not exposed externally (403, as intended)
- [ ] Laravel side not exercised here (no public host route in this stack); manifest read path is identical (same JSON, same mount), so no expected divergence